### PR TITLE
added workflow

### DIFF
--- a/.github/workflows/build-cloud-gov.yml
+++ b/.github/workflows/build-cloud-gov.yml
@@ -1,0 +1,151 @@
+on:
+  workflow_dispatch:
+    inputs:
+      build_deps:
+        description: 'Also build R dependencies?'
+        required: true
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  copy_code_to_cloud-gov:
+    runs-on: ubuntu-latest
+    name: Copy default branch code to shiny-app folder within cloud-gov branch
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
+        ref: cloud-gov
+
+    - name: Delete shiny-app and main-branch folders if they exist
+      run: |
+        if [ -d "shiny-app" ]; then rm -fr shiny-app; fi
+        if [ -d "main-branch" ]; then rm -fr main-branch; fi
+
+    - name: Checkout default branch to main-branch path
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
+        path: main-branch
+
+    - name: Copy everything but .git*, Commit, and Push
+      if: ${{ success() }}
+      run: |
+        mkdir shiny-app
+        find main-branch/* -maxdepth 0 ! -name ".git*" -print0 | xargs -0 cp -r -t shiny-app
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git add shiny-app
+        git diff-index --quiet HEAD || git commit -m "Automated workflow from GitHub Actions to copy R Shiny app from default branch"
+        git push
+      env:
+        BUILD_DEPS: ${{ inputs.build_deps }}
+
+  download_and_vendor_dependencies:
+    if: ${{ inputs.build_deps }}
+    needs: copy_code_to_cloud-gov
+    runs-on: ubuntu-latest
+    name: Compile and vendor R dependencies for cloud.gov
+    defaults:
+      run:
+        working-directory: /workspace
+    container:
+      image: cloudfoundry/cflinuxfs4
+      volumes: 
+       - ${{ github.workspace }}:/workspace
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
+        ref: cloud-gov
+
+    - name: Setup Git and remove problematic packages
+      run: |
+        git config --global --add safe.directory $(realpath .)
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        sudo apt --purge autoremove -y libmariadb-dev libmariadb-dev-compat
+        
+    - name: Setup R
+      uses: r-lib/actions/setup-r@v2
+      with:
+        r-version: 4.2.2
+
+    - name: Setup pandoc
+      uses: r-lib/actions/setup-pandoc@v2
+
+    - name: Install R dependencies
+      uses: r-lib/actions/setup-r-dependencies@v2
+      with:
+        packages: |
+          stringr
+          devtools
+          sf
+
+    - name: List R dependencies
+      run: |
+        sed -n -e 's/^.*- name: //p' r.yml | tr -d '\015' | sed -n -e 'H;${x;s/\n/,/g;s/^,//;p;}' | xargs echo packs= >> $GITHUB_ENV
+
+    - name: Download R packages
+      run: |
+        if [ -d "vendor_r" ]; then rm -fr vendor_r; fi
+        if [ -f "r-build-deps.txt" ]; then rm r-build-deps.txt; fi
+        Rscript scripts/download_packages.R vendor_r/src/contrib ${{ env.packs }}
+        more r-build-deps.txt
+        if [ `grep sf r-build-deps.txt | wc -c` -gt 0 ]; then echo needs_geo=true; else echo needs_geo=false; fi >> $GITHUB_ENV
+        if [ `grep pandoc r-build-deps.txt | wc -c` -gt 0 ]; then echo needs_pandoc=true; else echo needs_pandoc=false; fi >> $GITHUB_ENV
+        # if [ -f "r-build-deps.txt" ]; then echo needs_libraries=true; else echo needs_libraries=false; fi >> $GITHUB_ENV
+
+    - name: Run lib_tar.sh to extract each of the libraries needed by sf
+      if: ${{ env.needs_geo == 'true' }}
+      run: |
+        cd vendor_r/src/contrib
+        find -name '*_R_x86_64-pc-linux-gnu.tar.gz' -print0 | sed -ze "p;s/\_R_x86_64-pc-linux-gnu//" | xargs -0 -n2 mv
+        cd ../../..
+        if [ -d "r-lib" ]; then rm -fr r-lib; fi
+        mkdir r-lib
+        chmod +x scripts/lib_tar.sh
+        for L in $LIBS
+        do
+          find / -iname $L 2>/dev/null | xargs -I {} scripts/lib_tar.sh {}
+        done
+        scripts/lib_tar.sh /usr/lib/x86_64-linux-gnu/libsqlite3.so.0    # Another libsqlite3.so.0 exists on the image
+        git add r-lib
+      env:
+        LIBS: libudunits2.so.0 libgeos_c.so libproj.so.22 proj.db libgdal.so.30
+
+    - name: Copy pandoc executable
+      if: ${{ env.needs_pandoc == 'true' }}
+      run: |
+        if [ -d "r-bin" ]; then rm -fr r-bin; fi
+        mkdir r-bin
+        cp /usr/bin/pandoc r-bin
+        git add r-bin
+        
+    - name: Add additional files to repo if not already there
+      run: |
+        if [ ! ls "manifest*.yml" 1> /dev/null 2>&1 ]; then
+          mv scripts/include/manifest.yml .
+          git add manifest.yml
+        fi
+        if [ ! -f ".cfignore" ]; then
+          mv scripts/include/.cfignore .
+          git add .cfignore
+        fi
+        if [ ! -f "shiny.R" ]; then
+          mv scripts/include/shiny.R .
+          git add shiny.R
+        fi
+
+    - name: Commit & Push
+      if: ${{ success() }}
+      run: |
+        git add vendor_r
+        git diff-index --quiet HEAD || git commit -m "Automated workflow from GitHub Actions to vendor R dependencies"
+        git push


### PR DESCRIPTION
This workflow will populate the cloud-gov branch with a copy of the default branch (develop) and generate R dependencies within the cloud-gov branch. I haven't been able to test it with TADAShiny yet, but it is running successfully on other projects such as [OW Survey Design Tool](https://github.com/USEPA/OW_Survey_Design_Tool) and only pushing changes to the cloud-gov branch.