### PR TITLE
Update the version of R in build workflow to 4.3.1

### DIFF
--- a/.github/workflows/build-cloud-gov.yml
+++ b/.github/workflows/build-cloud-gov.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Setup R
       uses: r-lib/actions/setup-r@v2
       with:
-        r-version: 4.2.3
+        r-version: 4.3.1
         use-public-rspm: true
 
     - name: Setup pandoc


### PR DESCRIPTION
Cloud.gov is currently on 4.3.1