### PR TITLE
Automatically starts shiny app when codespace is run

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,6 +24,6 @@
     },
     "postAttachCommand": {
         "rstudio-start": "sudo rstudio-server start",
-	"run-shiny-app": "R -e shiny::runApp(port = 37376)"
+	"run-shiny-app": "R -e 'shiny::runApp(port = 37376)'"
     }
-}
+}'

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,4 +26,4 @@
         "rstudio-start": "sudo rstudio-server start",
 	"run-shiny-app": "R -e 'shiny::runApp(port = 37376)'"
     }
-}'
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,29 +1,29 @@
 {
     "name": "R Studio Server",
     "image": "ghcr.io/rocker-org/devcontainer/geospatial:4",
-	"features": {
-          "ghcr.io/rocker-org/devcontainer-features/r-packages:1": {
+    "features": {
+        "ghcr.io/rocker-org/devcontainer-features/r-packages:1": {
             "packages": "github::USEPA/TADA,config,golem,readxl,writexl,leaflet,shiny,shinyWidgets,shinyjs,shinycssloaders,DT,ggplot2,shinybusy,dplyr,plyr,tidyr,scales,forcats,RColorBrewer,lubridate,plotly",
             "installSystemRequirements": true
-          }
-	},
+        }
+    },
     "forwardPorts": [
         8787
     ],
     "portsAttributes": {
-        "8787":{
+        "8787": {
             "label": "R Studio Server",
-		"requireLocalPort": true,
-		"onAutoForward": "ignore"
+            "requireLocalPort": true,
+            "onAutoForward": "ignore"
         },
-	"37376":{
+        "37376": {
             "label": "Shiny app",
-		"requireLocalPort": true,
-		"onAutoForward": "ignore"
+            "requireLocalPort": false,
+            "onAutoForward": "ignore"
         }
     },
     "postAttachCommand": {
         "rstudio-start": "sudo rstudio-server start",
-	"run-shiny-app": "R -e 'shiny::runApp(port = 37376)'"
+        "run-shiny-app": "R -e 'shiny::runApp(port = 37376)'"
     }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"name": "R Studio Server",
+    "name": "R Studio Server",
     "image": "ghcr.io/rocker-org/devcontainer/geospatial:4",
 	"features": {
         "ghcr.io/rocker-org/devcontainer-features/r-packages:1": {
@@ -15,9 +15,15 @@
             "label": "R Studio Server",
 			"requireLocalPort": true,
 			"onAutoForward": "ignore"
+        },
+	"37376":{
+            "label": "Shiny app",
+			"requireLocalPort": true,
+			"onAutoForward": "ignore"
         }
     },
     "postAttachCommand": {
-        "rstudio-start": "sudo rstudio-server start"
+        "rstudio-start": "sudo rstudio-server start",
+	"run-shiny-app": "R -e shiny::runApp(appDir = ${localWorkspaceFolder}, port = '37376')"
     }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "name": "R Studio Server",
+    "name": "R Studio Server and Shiny app",
     "image": "ghcr.io/rocker-org/devcontainer/geospatial:4",
     "features": {
         "ghcr.io/rocker-org/devcontainer-features/r-packages:1": {
@@ -19,7 +19,7 @@
         },
         "37376": {
             "label": "Shiny app",
-            "requireLocalPort": false,
+            "requireLocalPort": true,
             "onAutoForward": "ignore"
         }
     },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,8 @@
         }
     },
     "forwardPorts": [
-        8787
+        8787,
+        37376
     ],
     "portsAttributes": {
         "8787": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,10 +2,10 @@
     "name": "R Studio Server",
     "image": "ghcr.io/rocker-org/devcontainer/geospatial:4",
 	"features": {
-        "ghcr.io/rocker-org/devcontainer-features/r-packages:1": {
+          "ghcr.io/rocker-org/devcontainer-features/r-packages:1": {
             "packages": "github::USEPA/TADA,config,golem,readxl,writexl,leaflet,shiny,shinyWidgets,shinyjs,shinycssloaders,DT,ggplot2,shinybusy,dplyr,plyr,tidyr,scales,forcats,RColorBrewer,lubridate,plotly",
             "installSystemRequirements": true
-        }
+          }
 	},
     "forwardPorts": [
         8787
@@ -13,17 +13,17 @@
     "portsAttributes": {
         "8787":{
             "label": "R Studio Server",
-			"requireLocalPort": true,
-			"onAutoForward": "ignore"
+		"requireLocalPort": true,
+		"onAutoForward": "ignore"
         },
 	"37376":{
             "label": "Shiny app",
-			"requireLocalPort": true,
-			"onAutoForward": "ignore"
+		"requireLocalPort": true,
+		"onAutoForward": "ignore"
         }
     },
     "postAttachCommand": {
         "rstudio-start": "sudo rstudio-server start",
-	"run-shiny-app": "R -e shiny::runApp(appDir = ${localWorkspaceFolder}, port = '37376')"
+	"run-shiny-app": "R -e shiny::runApp(port = 37376)"
     }
 }


### PR DESCRIPTION
This will automatically start the Shiny app on port 37376 and forward that port when the codespace is started