### PR TITLE
Remove cloud foundry container from workflow

### DIFF
--- a/.github/workflows/build-cloud-gov.yml
+++ b/.github/workflows/build-cloud-gov.yml
@@ -137,10 +137,8 @@ jobs:
       if: ${{ env.needs_pandoc == 'true' && inputs.build_bins }}
       run: |
         if [ -d "bin" ]; then rm -fr bin; fi
-        mkdir temp_bin
-        cp /usr/bin/pandoc temp_bin
         mkdir bin
-        tar -czvf bin/pandoc.tar.gz
+        tar -czvf bin/pandoc.tar.gz /usr/bin/pandoc
         git add bin
         
     - name: Add additional files to repo if not already there

--- a/.github/workflows/build-cloud-gov.yml
+++ b/.github/workflows/build-cloud-gov.yml
@@ -62,10 +62,10 @@ jobs:
     defaults:
       run:
         working-directory: /workspace
-    container:
-      image: cloudfoundry/cflinuxfs4
-      volumes: 
-       - ${{ github.workspace }}:/workspace
+    # container:
+    #   image: cloudfoundry/cflinuxfs4
+    #   volumes: 
+    #    - ${{ github.workspace }}:/workspace
 
     steps:
     - name: Checkout Code
@@ -157,7 +157,7 @@ jobs:
         fi
       
     - name: Upload folder debug-outputs to an artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: debug-outputs
         path: debug-outputs
@@ -178,7 +178,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Workflow to copy for deployment
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.OWSHINY_ACTION }}
           script: |

--- a/.github/workflows/build-cloud-gov.yml
+++ b/.github/workflows/build-cloud-gov.yml
@@ -59,13 +59,6 @@ jobs:
     needs: copy_code_to_cloud-gov
     runs-on: ubuntu-latest
     name: Compile and vendor R dependencies for cloud.gov
-    # defaults:
-    #   run:
-    #     working-directory: /workspace
-    # container:
-    #   image: cloudfoundry/cflinuxfs4
-    #   volumes: 
-    #    - ${{ github.workspace }}:/workspace
 
     steps:
     - name: Checkout Code

--- a/.github/workflows/build-cloud-gov.yml
+++ b/.github/workflows/build-cloud-gov.yml
@@ -137,8 +137,10 @@ jobs:
       if: ${{ env.needs_pandoc == 'true' && inputs.build_bins }}
       run: |
         if [ -d "bin" ]; then rm -fr bin; fi
+        mkdir temp_bin
+        cp /usr/bin/pandoc temp_bin
         mkdir bin
-        cp /usr/bin/pandoc bin
+        tar -czvf bin/pandoc.tar.gz
         git add bin
         
     - name: Add additional files to repo if not already there

--- a/.github/workflows/build-cloud-gov.yml
+++ b/.github/workflows/build-cloud-gov.yml
@@ -59,9 +59,9 @@ jobs:
     needs: copy_code_to_cloud-gov
     runs-on: ubuntu-latest
     name: Compile and vendor R dependencies for cloud.gov
-    defaults:
-      run:
-        working-directory: /workspace
+    # defaults:
+    #   run:
+    #     working-directory: /workspace
     # container:
     #   image: cloudfoundry/cflinuxfs4
     #   volumes: 


### PR DESCRIPTION
Updates the build-cloud-gov workflow to run on a standard ubuntu-latest image instead of a cloud foundry container