### PR TITLE
Production release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,8 +43,7 @@ Imports:
     grDevices,
     lubridate,
     plotly, 
-    shinyjs, 
-    lwgeom
+    shinyjs
 Remotes: 
     github::USEPA/EPATADA
 Suggests: 
@@ -67,5 +66,5 @@ Config/testthat/load-all: list(export_all = FALSE, helpers = FALSE)
 LazyData: true
 URL: https://github.com/USEPA/TADAShiny
 BugReports: https://github.com/USEPA/TADAShiny/issues
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Roxygen: list(markdown = TRUE)

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -24,10 +24,13 @@ app_ui <- function(request) {
     # Your application UI logic
     shiny::fluidPage(
       tags$html(class = "no-js", lang = "en"),
-      HTML("<div id='eq-disclaimer-banner' class='padding-1 text-center text-white bg-secondary-dark'><strong>EPA development environment:</strong> The
-      content on this page is not production ready. This site is being used
-      for <strong>development</strong> and/or <strong>testing</strong> purposes
-      only.</div>"),
+      
+      # adds development banner
+      # HTML("<div id='eq-disclaimer-banner' class='padding-1 text-center text-white bg-secondary-dark'><strong>EPA development environment:</strong> The
+      # content on this page is not production ready. This site is being used
+      # for <strong>development</strong> and/or <strong>testing</strong> purposes
+      # only.</div>"),
+      
       # adds epa header html from here: https://www.epa.gov/themes/epa_theme/pattern-lab/patterns/pages-standalone-template/pages-standalone-template.rendered.html
       shiny::includeHTML(app_sys("app/www/header.html")),
       shinyjs::useShinyjs(),

--- a/R/mod_query_data.R
+++ b/R/mod_query_data.R
@@ -16,25 +16,27 @@ load("inst/extdata/query_choices.Rdata")
 # new (2024-05-23) list for new Country/Ocean(s) Query the Water Quality Portal option. Not included in saved query_choices file
 library(jsonlite)
 library(dplyr)
-url <- 'https://www.waterqualitydata.us/Codes/countrycode?mimeType=json'
-countryocean_source <- fromJSON(txt=url)
+countrycode_url <- 'https://www.waterqualitydata.us/Codes/countrycode?mimeType=json'
+countryocean_source <- fromJSON(txt=countrycode_url)
 countryocean_source <- countryocean_source$codes %>% select(-one_of('providers'))
 countryocean_source <- countryocean_source[order(countryocean_source$desc),]
 countryocean_choices <- countryocean_source$value
 names(countryocean_choices) <- countryocean_source$desc
 
-# Last run by EDH on 08/25/23
+# Last run by CAM on 09/16/24
 # county = readr::read_tsv(url("https://www2.census.gov/geo/docs/reference/codes/files/national_county.txt"), col_names = FALSE)
 # county = county%>%tidyr::separate(X1,into = c("STUSAB","STATE","COUNTY","COUNTY_NAME","COUNTY_ID"), sep=",")
 # orgs = unique(utils::read.csv(url("https://cdx.epa.gov/wqx/download/DomainValues/Organization.CSV"))$ID)
 # chars = unique(utils::read.csv(url("https://cdx.epa.gov/wqx/download/DomainValues/Characteristic.CSV"))$Name)
 # chargroup = unique(utils::read.csv(url("https://cdx.epa.gov/wqx/download/DomainValues/CharacteristicGroup.CSV"))$Name)
 # media = c(unique(utils::read.csv(url("https://cdx.epa.gov/wqx/download/DomainValues/ActivityMedia.CSV"))$Name),"water","Biological Tissue","No media")
-# # sitetype = unique(utils::read.csv(url("https://cdx.epa.gov/wqx/download/DomainValues/MonitoringLocationType.CSV"))$Name)
+# sitetype = unique(utils::read.csv(url("https://cdx.epa.gov/wqx/download/DomainValues/MonitoringLocationType.CSV"))$Name)
 # sitetype = c("Aggregate groundwater use","Aggregate surface-water-use","Aggregate water-use establishment","Atmosphere","Estuary","Facility","Glacier","Lake, Reservoir, Impoundment","Land","Not Assigned","Ocean","Spring","Stream","Subsurface","Well","Wetland")
 # projects = unique(data.table::fread("https://www.waterqualitydata.us/data/Project/search?mimeType=csv&zip=no&providers=NWIS&providers=STEWARDS&providers=STORET")$ProjectIdentifier)
-# mlids = unique(data.table::fread("https://www.waterqualitydata.us/data/Station/search?mimeType=csv&zip=no&providers=NWIS&providers=STEWARDS&providers=STORET")$MonitoringLocationIdentifier)
-# save(orgs, chars, chargroup, media, county, sitetype, projects, mlids, file = "inst/extdata/query_choices.Rdata")
+# # not working
+# # mlids = unique(data.table::fread("https://www.waterqualitydata.us/data/Station/search?mimeType=csv&zip=no&providers=NWIS&providers=STEWARDS&providers=STORET")$MonitoringLocationIdentifier)
+# # removing mlids for now
+# save(orgs, chars, chargroup, media, county, sitetype, projects, file = "inst/extdata/query_choices.Rdata")
 
 mod_query_data_ui <- function(id) {
   ns <- NS(id)
@@ -102,11 +104,11 @@ mod_query_data_ui <- function(id) {
       )
     ),
     shiny::fluidRow(
-      column(4, 
-             shiny::selectizeInput(ns("siteid"),
-             "Monitoring Location ID(s)",
-             choices = NULL,
-             multiple = TRUE)),
+      # column(4,
+      #        shiny::selectizeInput(ns("siteid"),
+      #        "Monitoring Location ID(s)",
+      #        choices = NULL,
+      #        multiple = TRUE)),
       column(4, 
              shiny::selectizeInput(ns("countryocean"),
              "Country/Ocean(s)", 
@@ -121,6 +123,7 @@ mod_query_data_ui <- function(id) {
           ns("org"),
           "Organization(s)",
           choices = NULL,
+          options = list(placeholder = "Start typing or use drop down menu"),
           multiple = TRUE
         )
       ),
@@ -130,6 +133,7 @@ mod_query_data_ui <- function(id) {
           ns("project"),
           "Project(s)",
           choices = NULL,
+          options = list(placeholder = "Start typing or use drop down menu"),
           multiple = TRUE
         )
       ),
@@ -139,6 +143,7 @@ mod_query_data_ui <- function(id) {
           ns("type"),
           "Site Type(s)",
           choices = c(sitetype),
+          options = list(placeholder = "Start typing or use drop down menu"),
           multiple = TRUE
         )
       )
@@ -164,20 +169,22 @@ mod_query_data_ui <- function(id) {
       column(
         4,
         shiny::selectizeInput(
-          ns("chargroup"), 
-          "Characteristic Group", 
+          ns("characteristic"),
+          "Characteristic(s)",
           choices = NULL,
+          options = list(placeholder = "Start typing or use drop down menu"),
           multiple = TRUE
-          )
+        )
       ),
       column(
         4,
         shiny::selectizeInput(
-          ns("characteristic"),
-          "Characteristic(s)",
+          ns("chargroup"), 
+          "Characteristic Group", 
           choices = NULL,
+          options = list(placeholder = "Start typing or use drop down menu"),
           multiple = TRUE
-        )
+          )
       )
     ),
     shiny::fluidRow(
@@ -323,8 +330,9 @@ mod_query_data_server <- function(id, tadat) {
       session,
       "chargroup",
       choices = c(chargroup),
-      selected = character(0),
-      options = list(placeholder = ""),
+      # selected = character(0),
+      # options = list(placeholder = ""),
+      options = list(placeholder = "Start typing or use drop down menu"),
       server = TRUE
     )
     shiny::updateSelectizeInput(session,
@@ -335,17 +343,16 @@ mod_query_data_server <- function(id, tadat) {
     shiny::updateSelectizeInput(session,
       "project",
       choices = c(projects),
-      server = TRUE
-    )
-    shiny::updateSelectizeInput(
-      session,
-      "siteid",
-      choices = c(mlids),
       options = list(placeholder = "Start typing or use drop down menu"),
       server = TRUE
     )
-
-    
+    # shiny::updateSelectizeInput(
+    #   session,
+    #   "siteid",
+    #   choices = c(mlids),
+    #   options = list(placeholder = "Start typing or use drop down menu"),
+    #   server = TRUE
+    # )
     shiny::updateSelectizeInput(
       session,
       "countryocean",
@@ -407,6 +414,11 @@ mod_query_data_server <- function(id, tadat) {
       } else {
         tadat$huc <- input$huc
       }
+      # if (is.null(input$siteid)) {
+      #   tadat$siteid <- "null"
+      # } else {
+      #   tadat$siteid <- input$siteid
+      # }
       if (is.null(input$type)) {
         tadat$siteType <- "null"
       } else {
@@ -437,12 +449,7 @@ mod_query_data_server <- function(id, tadat) {
       } else {
         tadat$organization <- input$org
       }
-      if (is.null(input$siteid)) {
-        tadat$siteid <- "null"
-      } else {
-        tadat$siteid <- input$siteid
-        # siteid = stringr::str_trim(unlist(strsplit(input$siteids,",")))
-      }
+      
       if (length(input$endDate) == 0) {
         # ensure if date is empty, the query receives a proper input ("null")
         tadat$endDate <- "null"
@@ -469,7 +476,7 @@ mod_query_data_server <- function(id, tadat) {
         countycode = tadat$countycode,
         countrycode = tadat$countrycode,
         huc = tadat$huc,
-        siteid = tadat$siteid,
+        # siteid = tadat$siteid,
         siteType = tadat$siteType,
         characteristicName = tadat$characteristicName,
         characteristicType = tadat$characteristicType,
@@ -513,12 +520,9 @@ mod_query_data_server <- function(id, tadat) {
           shiny::updateSelectizeInput(session, "state", selected = tadat$statecode)
           shiny::updateSelectizeInput(session, "county", selected = tadat$countycode)
           shiny::updateTextInput(session, "huc")
-          shiny::updateSelectizeInput(session, "siteid", selected = tadat$siteid)
+          # shiny::updateSelectizeInput(session, "siteid", selected = tadat$siteid)
           shiny::updateSelectizeInput(session, "type", selected = tadat$siteType)
-          shiny::updateSelectizeInput(session,
-            "characteristic",
-            selected = tadat$characteristicName
-          )
+          shiny::updateSelectizeInput(session, "characteristic", selected = tadat$characteristicName)
           shiny::updateSelectizeInput(session, "chargroup", selected = tadat$characteristicType)
           shiny::updateSelectizeInput(session, "media", selected = tadat$sampleMedia)
           shiny::updateSelectizeInput(session, "project", selected = tadat$project)

--- a/R/mod_query_data.R
+++ b/R/mod_query_data.R
@@ -185,7 +185,8 @@ mod_query_data_ui <- function(id) {
              4,
              shiny::checkboxGroupInput(ns("providers"), 
              "Data Source", 
-             c("NWIS (USGS)" = "NWIS", "WQX (EPA)" = "STORET"))
+             c("NWIS (USGS)" = "NWIS", "WQX (EPA)" = "STORET"), 
+             selected = c("NWIS", "STORET"))
       )
     ),
     shiny::fluidRow(column(

--- a/R/mod_query_data.R
+++ b/R/mod_query_data.R
@@ -347,7 +347,7 @@ mod_query_data_server <- function(id, tadat) {
     shiny::updateSelectizeInput(
       session,
       "siteid",
-      choices = c(mlids),
+      choices = c(mlids2),
       options = list(placeholder = "Start typing or use drop down menu"),
       server = TRUE
     )

--- a/R/mod_query_data.R
+++ b/R/mod_query_data.R
@@ -23,20 +23,18 @@ countryocean_source <- countryocean_source[order(countryocean_source$desc),]
 countryocean_choices <- countryocean_source$value
 names(countryocean_choices) <- countryocean_source$desc
 
-# Last run by CAM on 09/16/24
+# # Last run by CAM on 09/16/24
 # county = readr::read_tsv(url("https://www2.census.gov/geo/docs/reference/codes/files/national_county.txt"), col_names = FALSE)
 # county = county%>%tidyr::separate(X1,into = c("STUSAB","STATE","COUNTY","COUNTY_NAME","COUNTY_ID"), sep=",")
 # orgs = unique(utils::read.csv(url("https://cdx.epa.gov/wqx/download/DomainValues/Organization.CSV"))$ID)
 # chars = unique(utils::read.csv(url("https://cdx.epa.gov/wqx/download/DomainValues/Characteristic.CSV"))$Name)
 # chargroup = unique(utils::read.csv(url("https://cdx.epa.gov/wqx/download/DomainValues/CharacteristicGroup.CSV"))$Name)
 # media = c(unique(utils::read.csv(url("https://cdx.epa.gov/wqx/download/DomainValues/ActivityMedia.CSV"))$Name),"water","Biological Tissue","No media")
-# sitetype = unique(utils::read.csv(url("https://cdx.epa.gov/wqx/download/DomainValues/MonitoringLocationType.CSV"))$Name)
+# # sitetype = unique(utils::read.csv(url("https://cdx.epa.gov/wqx/download/DomainValues/MonitoringLocationType.CSV"))$Name)
 # sitetype = c("Aggregate groundwater use","Aggregate surface-water-use","Aggregate water-use establishment","Atmosphere","Estuary","Facility","Glacier","Lake, Reservoir, Impoundment","Land","Not Assigned","Ocean","Spring","Stream","Subsurface","Well","Wetland")
-# projects = unique(data.table::fread("https://www.waterqualitydata.us/data/Project/search?mimeType=csv&zip=no&providers=NWIS&providers=STEWARDS&providers=STORET")$ProjectIdentifier)
-# # not working
-# # mlids = unique(data.table::fread("https://www.waterqualitydata.us/data/Station/search?mimeType=csv&zip=no&providers=NWIS&providers=STEWARDS&providers=STORET")$MonitoringLocationIdentifier)
-# # removing mlids for now
-# save(orgs, chars, chargroup, media, county, sitetype, projects, file = "inst/extdata/query_choices.Rdata")
+# projects = unique(data.table::fread("https://www.waterqualitydata.us/data/Project/search?mimeType=csv&zip=no&providers=NWIS&providers=STORET")$ProjectIdentifier)
+# mlids = unique(data.table::fread("https://www.waterqualitydata.us/data/Station/search?mimeType=csv&zip=no")$MonitoringLocationIdentifier)
+# save(orgs, chars, chargroup, media, county, sitetype, projects, mlids2, file = "inst/extdata/query_choices.Rdata")
 
 mod_query_data_ui <- function(id) {
   ns <- NS(id)
@@ -104,11 +102,11 @@ mod_query_data_ui <- function(id) {
       )
     ),
     shiny::fluidRow(
-      # column(4,
-      #        shiny::selectizeInput(ns("siteid"),
-      #        "Monitoring Location ID(s)",
-      #        choices = NULL,
-      #        multiple = TRUE)),
+      column(4,
+             shiny::selectizeInput(ns("siteid"),
+             "Monitoring Location ID(s)",
+             choices = NULL,
+             multiple = TRUE)),
       column(4, 
              shiny::selectizeInput(ns("countryocean"),
              "Country/Ocean(s)", 
@@ -346,13 +344,13 @@ mod_query_data_server <- function(id, tadat) {
       options = list(placeholder = "Start typing or use drop down menu"),
       server = TRUE
     )
-    # shiny::updateSelectizeInput(
-    #   session,
-    #   "siteid",
-    #   choices = c(mlids),
-    #   options = list(placeholder = "Start typing or use drop down menu"),
-    #   server = TRUE
-    # )
+    shiny::updateSelectizeInput(
+      session,
+      "siteid",
+      choices = c(mlids),
+      options = list(placeholder = "Start typing or use drop down menu"),
+      server = TRUE
+    )
     shiny::updateSelectizeInput(
       session,
       "countryocean",
@@ -414,11 +412,11 @@ mod_query_data_server <- function(id, tadat) {
       } else {
         tadat$huc <- input$huc
       }
-      # if (is.null(input$siteid)) {
-      #   tadat$siteid <- "null"
-      # } else {
-      #   tadat$siteid <- input$siteid
-      # }
+      if (is.null(input$siteid)) {
+        tadat$siteid <- "null"
+      } else {
+        tadat$siteid <- input$siteid
+      }
       if (is.null(input$type)) {
         tadat$siteType <- "null"
       } else {
@@ -476,7 +474,7 @@ mod_query_data_server <- function(id, tadat) {
         countycode = tadat$countycode,
         countrycode = tadat$countrycode,
         huc = tadat$huc,
-        # siteid = tadat$siteid,
+        siteid = tadat$siteid,
         siteType = tadat$siteType,
         characteristicName = tadat$characteristicName,
         characteristicType = tadat$characteristicType,
@@ -520,7 +518,7 @@ mod_query_data_server <- function(id, tadat) {
           shiny::updateSelectizeInput(session, "state", selected = tadat$statecode)
           shiny::updateSelectizeInput(session, "county", selected = tadat$countycode)
           shiny::updateTextInput(session, "huc")
-          # shiny::updateSelectizeInput(session, "siteid", selected = tadat$siteid)
+          shiny::updateSelectizeInput(session, "siteid", selected = tadat$siteid)
           shiny::updateSelectizeInput(session, "type", selected = tadat$siteType)
           shiny::updateSelectizeInput(session, "characteristic", selected = tadat$characteristicName)
           shiny::updateSelectizeInput(session, "chargroup", selected = tadat$characteristicType)

--- a/R/mod_query_data.R
+++ b/R/mod_query_data.R
@@ -12,6 +12,17 @@
 
 load("inst/extdata/statecodes_df.Rdata")
 load("inst/extdata/query_choices.Rdata")
+
+# new (2024-05-23) list for new Country/Ocean(s) Query the Water Quality Portal option. Not included in saved query_choices file
+library(jsonlite)
+library(dplyr)
+url <- 'https://www.waterqualitydata.us/Codes/countrycode?mimeType=json'
+countryocean_source <- fromJSON(txt=url)
+countryocean_source <- countryocean_source$codes %>% select(-one_of('providers'))
+countryocean_source <- countryocean_source[order(countryocean_source$desc),]
+countryocean_choices <- countryocean_source$value
+names(countryocean_choices) <- countryocean_source$desc
+
 # Last run by EDH on 08/25/23
 # county = readr::read_tsv(url("https://www2.census.gov/geo/docs/reference/codes/files/national_county.txt"), col_names = FALSE)
 # county = county%>%tidyr::separate(X1,into = c("STUSAB","STATE","COUNTY","COUNTY_NAME","COUNTY_ID"), sep=",")
@@ -90,16 +101,19 @@ mod_query_data_ui <- function(id) {
         shiny::textInput(ns("huc"), "Hydrologic Unit", placeholder = "e.g. 020700100103")
       )
     ),
-    shiny::fluidRow(column(
-      4,
-      shiny::selectizeInput(
-        ns("siteid"),
-        "Monitoring Location ID(s)",
-        choices = NULL,
-        multiple = TRUE
-      )
-    )),
-    htmltools::h4("Metadata Filters"),
+    shiny::fluidRow(
+      column(4, 
+             shiny::selectizeInput(ns("siteid"),
+             "Monitoring Location ID(s)",
+             choices = NULL,
+             multiple = TRUE)),
+      column(4, 
+             shiny::selectizeInput(ns("countryocean"),
+             "Country/Ocean(s)", 
+             choices = NULL, 
+             multiple = TRUE))
+    ),
+    htmltools::h4("Metadata Filters"),   
     shiny::fluidRow(
       column(
         4,
@@ -149,7 +163,12 @@ mod_query_data_ui <- function(id) {
       ),
       column(
         4,
-        shiny::selectizeInput(ns("chargroup"), "Characteristic Group", choices = NULL)
+        shiny::selectizeInput(
+          ns("chargroup"), 
+          "Characteristic Group", 
+          choices = NULL,
+          multiple = TRUE
+          )
       ),
       column(
         4,
@@ -159,6 +178,14 @@ mod_query_data_ui <- function(id) {
           choices = NULL,
           multiple = TRUE
         )
+      )
+    ),
+    shiny::fluidRow(
+      column(
+             4,
+             shiny::checkboxGroupInput(ns("providers"), 
+             "Data Source", 
+             c("NWIS (USGS)" = "NWIS", "WQX (EPA)" = "STORET"))
       )
     ),
     shiny::fluidRow(column(
@@ -317,6 +344,17 @@ mod_query_data_server <- function(id, tadat) {
       server = TRUE
     )
 
+    
+    shiny::updateSelectizeInput(
+      session,
+      "countryocean",
+      choices = countryocean_choices,
+      selected = character(0),
+      options = list(placeholder = "Start typing or use drop down menu"),
+      server = TRUE
+    )
+    
+
     # this observes when the user inputs a state into the drop down and subsets the choices for counties to only those counties within that state.
     shiny::observeEvent(input$state, {
       state_counties <- subset(county, county$STUSAB == input$state)
@@ -352,6 +390,17 @@ mod_query_data_server <- function(id, tadat) {
       } else {
         tadat$countycode <- input$county
       }
+      # this is an overloaded field which can be 2-character Country or Ocean
+      if (is.null(input$countryocean)) {
+        tadat$countrycode <- "null"
+      } else {
+        tadat$countrycode <- input$countryocean
+      }
+      if (is.null(input$providers)) {
+        tadat$providers <- "null"
+      } else {
+        tadat$providers <- input$providers
+      }
       if (input$huc == "") {
         tadat$huc <- "null"
       } else {
@@ -362,7 +411,7 @@ mod_query_data_server <- function(id, tadat) {
       } else {
         tadat$siteType <- input$type
       }
-      if (input$chargroup == "") {
+      if (is.null(input$chargroup)) {
         tadat$characteristicType <- "null"
       } else {
         tadat$characteristicType <- input$chargroup
@@ -380,7 +429,7 @@ mod_query_data_server <- function(id, tadat) {
       if (is.null(input$project)) {
         tadat$project <- "null"
       } else {
-        tadat$project <- input$project
+        tadat$project <- paste(input$project, collapse = ",")
       }
       if (is.null(input$org)) {
         tadat$organization <- "null"
@@ -417,6 +466,7 @@ mod_query_data_server <- function(id, tadat) {
       raw <- EPATADA::TADA_DataRetrieval(
         statecode = tadat$statecode,
         countycode = tadat$countycode,
+        countrycode = tadat$countrycode,
         huc = tadat$huc,
         siteid = tadat$siteid,
         siteType = tadat$siteType,
@@ -427,6 +477,7 @@ mod_query_data_server <- function(id, tadat) {
         organization = tadat$organization,
         startDate = tadat$startDate,
         endDate = tadat$endDate,
+        providers = tadat$providers,
         applyautoclean = TRUE
       )
 

--- a/R/utils_flag_functions.R
+++ b/R/utils_flag_functions.R
@@ -114,11 +114,10 @@ applyFlags <- function(in_table, orgs) {
     out <- EPATADA::TADA_FindQAPPDoc(out, clean = FALSE)
   }
 
-  # Dataset includes depth profile data - no function for this yet
-  # out <- out
-
-  # Aggregated continuous data
-  # out <- EPATADA::TADA_FlagContinuousData(out, clean = FALSE, flaggedonly = FALSE)
+  # Continuous data
+  out <- EPATADA::TADA_FlagContinuousData(out, clean = FALSE, 
+                                          flaggedonly = FALSE, 
+                                          time_difference = 4)
 
   # Above WQX Upper Threshold
   out <- EPATADA::TADA_FlagAboveThreshold(out, clean = FALSE)

--- a/inst/flag_prompts.csv
+++ b/inst/flag_prompts.csv
@@ -15,3 +15,4 @@ Order,Level,Prompt,flagType
 14,Optional,"Result value(s) below the national threshold for a given characteristic, possibly indicating non-sensical value(s) (see TADA.ResultValueBelowLowerThreshold.Flag)","Result value(s) below the national lower threshold for a given characteristic, possibly indicating non-sensical value(s)"
 15,Optional,Coordinates are outside of the United States (see TADA.InvalidCoordinates.Flag),Coordinates are outside of the United States
 16,Optional,Coordinates are imprecise (less than three decimal digits) (see TADA.InvalidCoordinates.Flag),Coordinates are imprecise (less than three decimal digits)
+17,Optional,Metadata indicates result values are less than 4 hours apart and are likely from continuous monitoring probes (sensors). Continuous data may (or may not) be suitable for integration with discrete water quality data for analyses.,Continuous results

--- a/inst/flag_prompts.csv
+++ b/inst/flag_prompts.csv
@@ -1,5 +1,5 @@
 Order,Level,Prompt,flagType
-1,Required,Result value is not numeric or NA and no detection limit value is provided (see TADA.ResultMeasureValueDataTypes.Flag),Result value is not numeric or NA and no detection limit value is provided
+1,Required,Result value is not numeric (text) OR result value is NA and no detection limit value is provided (see TADA.ResultMeasureValueDataTypes.Flag),Result value is not numeric or NA and no detection limit value is provided
 2,Required,Result value is not numeric or NA and the detection limit value cannot be interpreted because there is a conflict between the detection condition text and detection limit type provided by the data submitter [or the detection limit type is not in WQX domain tables (USGS/NWIS-specific)] (see TADA.CensoredData.Flag),Result value is not numeric or NA and the detection limit value cannot be interpreted because there is a conflict between the detection condition text and detection limit type provided by the data submitter [or the detection limit type is not in WQX domain tables (USGS/NWIS-specific)]
 3,Recommended,Suspect characteristic and speciation combination (see TADA.MethodSpeciation.Flag),Suspect characteristic and speciation combination
 4,Recommended,Suspect characteristic and fraction combination (see TADA.SampleFraction.Flag),Suspect characteristic and fraction combination

--- a/inst/flag_tests.csv
+++ b/inst/flag_tests.csv
@@ -77,3 +77,5 @@ Suspect characteristic and fraction combination,TADA.SampleFraction.Flag,Accepte
 Suspect characteristic and fraction combination,TADA.SampleFraction.Flag,Rejected,0,1
 Metadata indicates duplicative uploads of the same results within a single organization,TADA.SingleOrgDup.Flag,Duplicate,0,1
 Metadata indicates duplicative uploads of the same results within a single organization,TADA.SingleOrgDup.Flag,Unique,0,0
+Continuous results,TADA.ContinuousData.Flag,Continuous,0,1
+Continuous results,TADA.ContinuousData.Flag,Discrete,0,0


### PR DESCRIPTION
- removes development banner
- update mod_query_data.R with updates from https://github.com/USEPA/TADAShiny/pull/164 (fixes for 3 issues - https://github.com/USEPA/TADAShiny/issues/140 Fix characterisitic group filter on import tab, https://github.com/USEPA/TADAShiny/issues/146 Import tab missing country code filter, and https://github.com/USEPA/TADAShiny/issues/129 Add providers as a filter option on import tab)
- improve flag prompt wording (Result value is not numeric (text) OR result value is NA and no detection limit value is provided)
- removes lwgeom from imports in description file
- removes siteid query option because I was not able to generate a list of valid siteids (https://www.waterqualitydata.us/data/Station/search?mimeType=csv&zip=no&providers=NWIS&providers=STEWARDS&providers=STORET")$MonitoringLocationIdentifier) when updating the pick lists for all query filters. All other lists have been updated