### PR TITLE
Disable Load button until option selected

### DIFF
--- a/R/mod_query_data.R
+++ b/R/mod_query_data.R
@@ -58,6 +58,7 @@ mod_query_data_ui <- function(id) {
         ns("example_data_go"),
         "Load",
         shiny::icon("truck-ramp-box"),
+        disabled = TRUE,
         style = "color: #fff; background-color: #337ab7; border-color: #2e6da4"
       )
     )),
@@ -256,6 +257,13 @@ mod_query_data_server <- function(id, tadat) {
   shiny::moduleServer(id, function(input, output, session) {
     ns <- session$ns
 
+    # https://stackoverflow.com/questions/24175997/force-no-default-selection-in-selectinput
+    shiny::observeEvent(input$example_data, {
+      if (!is.na(input$example_data) && nchar(input$example_data) > 1) {
+          shinyjs::enable("example_data_go")
+      } 
+    })
+    
     # read in the excel spreadsheet dataset if this input reactive object is populated via fileInput and define as tadat$raw
     shiny::observeEvent(input$file, {
       # a modal that pops up showing it's working on querying the portal


### PR DESCRIPTION
Prevent fatal error by disabling Load button on Load tab until the user has selected an Example dataset.