### PR TITLE
providers as a filter option on import tab #129

### DIFF
--- a/R/mod_query_data.R
+++ b/R/mod_query_data.R
@@ -188,10 +188,9 @@ mod_query_data_ui <- function(id) {
     shiny::fluidRow(
       column(
              4,
-             shiny::checkboxGroupInput(ns("providers"), 
+             shiny::radioButtons(ns("providers"), 
              "Data Source", 
-             c("NWIS (USGS)" = "NWIS", "WQX (EPA)" = "STORET"), 
-             selected = c("NWIS", "STORET"))
+             c("NWIS (USGS)" = "NWIS", "WQX (EPA)" = "STORET", "Both (NWIS and WQX)" = "all"), selected = "all")
       )
     ),
     shiny::fluidRow(column(
@@ -402,7 +401,7 @@ mod_query_data_server <- function(id, tadat) {
       } else {
         tadat$countrycode <- input$countryocean
       }
-      if (is.null(input$providers)) {
+      if (is.null(input$providers) | input$providers == "all") {
         tadat$providers <- "null"
       } else {
         tadat$providers <- input$providers


### PR DESCRIPTION
Add Providers (EPA/NWIS) as a filter option on import tab #129.  And create a 'Select Both' option, and do not allow a Select None option.  This is a minor fix because Kevin realized that if a user de-selected both options as checkboxes then the application should warn them.  This makes that condition not possible.