### PR TITLE
Bisese october work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@
 _snaps
 .Ruserdata
 .vscode/
+tests/match_types.R
+inst/Characteristic.CSV
+tests/Characteristic.CSV
+tests/states.R
+tests/fruits.R

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -22,6 +22,8 @@ app_server <- function(input, output, session) {
     if (!is.null(tadat$raw) && is.null(tadat$removals)) {
       # Initialize removals with the same number of rows as raw data, all FALSE
       tadat$removals <- data.frame(matrix(FALSE, nrow = nrow(tadat$raw), ncol = 0))
+      # # 2025-11-17 consider making a parallel data for 'filtered' rows
+      # tadat$filters <- data.frame(matrix(FALSE, nrow = nrow(tadat$raw), ncol = 0))
     }
   })
   
@@ -37,6 +39,14 @@ app_server <- function(input, output, session) {
       # print(tadat$raw$TADA.Remove)
     }
   })
+  
+  # # New: Update the master 'Filter' column anytime data is added to the 'filters' table
+  # shiny::observeEvent(tadat$filters, {
+  #   if (dim(tadat$filters)[2] > 0) {
+  #     # 2025-11-17 consider making a parallel data for 'filtered' rows
+  #     tadat$raw$TADA.Filter <- apply(tadat$filters, 1, any)
+  #   }
+  # })
   
   # Module server calls
   mod_filtering_server("filtering_1", tadat)
@@ -64,7 +74,11 @@ app_server <- function(input, output, session) {
   tadat$save_progress_file <- NA
   tadat$flags_present <- FALSE
   job_id <- base::paste0("ts", format(Sys.time(), "%y%m%d%H%M%S"))
-  tadat$default_outfile <- base::paste0("tada_output_", job_id)
+  # note: this causes all excel files to have the same time stamp even if the user has been working for a long time.
+  # this prevents users from being able to compare excel files during the same session 
+  # since the 2 files with the same name can't be opened at the same time
+  # todo: consider creating the output file name at runtime
+  tadat$default_outfile <- base::paste0("tada_output_", job_id) 
   tadat$job_id <- job_id
   
   # Switch to overview tab when tadat$new changes and show a modal dialog

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -11,8 +11,13 @@ css <- "
 .nav li a.disabled {
   background-color: #F5F5F5 !important;
   color: #333 !important;
+  pointer-events: none; /* added 2025-Nov-17 Disable mouse events */
   cursor: not-allowed !important;
   border-color: #F5F5F5 !important;
+}
+/* This displays the custom cursor on the disabled anchor.  It gets overwritten when the nav li is activated. */
+.nav li {
+  cursor: not-allowed !important;
 }
 
 .row {

--- a/R/dev/draft/search_characteristics.R
+++ b/R/dev/draft/search_characteristics.R
@@ -1,6 +1,3 @@
-library(shiny)
-library(shinyjs)
-
 # this snippet runs the Characteristics search using a selectable 'match type'.
 # It uses a separate 'text_input' widget to search the values
 # to simplify the reactive behavior.  It might be possible to collapse

--- a/R/maintenance-utils.R
+++ b/R/maintenance-utils.R
@@ -16,7 +16,7 @@ utils::globalVariables(c(
   "nd_method", "nd_mult", "num", "num_chr", "od_method", "od_mult", "org_table",
   "organization", "original_source", "project", "resultCount", "sampleMedia",
   "selected_filters", "selected_flags", "siteType", "siteid", "startDate", "statecode",
-  "tot_n"
+  "tot_n", "TADA.RemovalReason"
 ))
 
 # Auto generates or updates TADAShiny-package.R file

--- a/R/mod_TADA_summary.R
+++ b/R/mod_TADA_summary.R
@@ -166,7 +166,13 @@ mod_TADA_summary_server <- function(id, tadat) {
           )
           
           # Filter data to exclude flagged removals for final dataset
+          # remove all rows where TADA.Remove is TRUE
           out_data <- EPATADA::TADA_OrderCols(tadat$raw[!tadat$raw$TADA.Remove, ])
+          
+          # remove these 2 columns since they are always FALSE and blank in that order
+          out_data <- subset(out_data, select = -TADA.Remove)
+          out_data <- subset(out_data, select = -TADA.RemovalReason)
+          
           summary_things$temp_files <- c(datafile_name, progress_file_name)
           desc <- writeNarrativeDataFrame(tadat)
           dfs <- list(Data = out_data, Parameterization = desc)

--- a/R/mod_data_flagging.R
+++ b/R/mod_data_flagging.R
@@ -134,6 +134,7 @@ mod_data_flagging_server <- function(id, tadat) {
     
     # Runs whenever selected flags are changed
     shiny::observeEvent(tadat$selected_flags, {
+      
       if (!is.null(tadat$removals)) {
         tadat$removals <- dplyr::select(tadat$removals, -(dplyr::starts_with(flag_prefix)))
       }
@@ -162,6 +163,29 @@ mod_data_flagging_server <- function(id, tadat) {
           }
         }
       }
+      
+      # start - create a column providing a text description of why the row is flagged for removal
+      # this is moved from mod_review_data.R
+      if (is.null(tadat$raw) == FALSE) {
+        removals <- tadat$removals
+        sel <- which(removals == TRUE, arr.ind = TRUE)
+        # todo might need to make sure sel is not NULL
+        if (length(sel) > 0) {
+          removals[sel] <- names(removals)[sel[, "col"]]
+          removals[removals == FALSE] <- ""
+          tadat$raw$TADA.RemovalReason <- apply(
+            removals, 1,
+            function(row) {
+              paste(row[nzchar(row)], collapse = ", ")
+            }
+          )
+        } else {
+          tadat$raw$TADA.RemovalReason <- NA
+        }
+      }
+      # end
+      
+      
     })
     
     # Any time tadat$raw is changed, check to see if the flagging fields are present

--- a/R/mod_filtering.R
+++ b/R/mod_filtering.R
@@ -284,6 +284,14 @@ mod_filtering_server <- function(id, tadat) {
           dplyr::select(tadat$removals, -(dplyr::starts_with(prefix)))
       }
 
+      # New: Remove all the filter columns from the filters table (start fresh)
+      # if (!is.null(tadat$filters)) {
+      #   tadat$filters <-
+      #     dplyr::select(tadat$filters, -(dplyr::starts_with(prefix)))
+      # }
+      
+      
+      
       # Only proceed if filters have been selected
       if (!(is.null(tadat$raw))) {
         # Enable the filtering tab. Usually happens when filters are loaded from a progress file
@@ -321,6 +329,8 @@ mod_filtering_server <- function(id, tadat) {
                 all_vals
               )
             tadat$removals[label] <- as.logical(results)
+            # new column with just filter information
+            # tadat$filters[label] <- as.logical(results)
           }
         }
 

--- a/R/mod_query_data.R
+++ b/R/mod_query_data.R
@@ -596,7 +596,6 @@ mod_query_data_server <- function(id, tadat) {
       # there is a more robust way to get the module Id required in setInputValue()
       # but I wasted time trying to get it working. This does work here.
       options = list(
-        searchField = "value",
         onType = I('
              text => Shiny.setInputValue("query_data_1-characteristic_select_search", text)
           ')
@@ -668,55 +667,87 @@ mod_query_data_server <- function(id, tadat) {
     })
 
     # reset the server-size selectize when 'Match type' changes
-    shiny::observeEvent(input$match_type_select, {
-      shiny::updateSelectizeInput(
-        session = session,
-        inputId = "characteristic_select",
-        choices = characteristic_list,
-        server = TRUE
-      )
-    }, ignoreInit = TRUE)
+    # shiny::observeEvent(input$match_type_select, {
+    #   
+    #   # TODO need to retain previous selection
+    #   previous_selected <- c(input$characteristic_select, input$characteristic_select_search)
+    #   
+    #   shiny::updateSelectizeInput(
+    #     session = session,
+    #     inputId = "characteristic_select",
+    #     choices = characteristic_list,
+    #     selected = previous_selected,
+    #     server = TRUE
+    #   )
+    # }, ignoreInit = TRUE)
   
+    
+      # shiny::observeEvent(input$characteristic_select, {
+      #   print(paste0('string: ', input$characteristic_select_search))
+      # })
+    
+    shiny::observeEvent(input$characteristic_select_blur, {
+      browser()
+      print(
+        "characteristic_select has blurred again!"
+      )
+    })
+    
+    
   # Reactive observer to listen for changes in the selectize input text string
-  shiny::observeEvent(input$characteristic_select_search, {
-
-    query <- input$characteristic_select_search
-
-    if (nchar(query) > 0) {
-          match_type <- 'contains'
-          if (input$match_type_select != '') {
-            match_type <- input$match_type_select
-          }
-          # set the grep pattern for each match type
-          if (match_type == 'starts_with') {
-            grep_pattern <- paste0("^", query)
-          }
-          else if (match_type == 'ends_with') {
-            grep_pattern <- paste0(query, "$")
-          }
-          else if (match_type == 'matches') {
-            grep_pattern <- paste0("^", query, "$")
-          }
-          else { # contains
-            grep_pattern <- query
-          }
-          filtered_characteristics <- characteristic_list[grep(
-            grep_pattern,
-            characteristic_list,
-            ignore.case = TRUE
-          )]
-    } 
-    else {
-      filtered_characteristics <- characteristic_list
-    }
-
-    shiny::updateSelectizeInput(
-      session = session,
-      inputId = "characteristic_select",
-      choices = filtered_characteristics,
-      server = TRUE
-    )
-  })
+  # shiny::observeEvent(input$characteristic_select_search, {
+  # # browser()
+  #   # TODO need to retain previous selection
+  #   previous_selected <- c(input$characteristic_select, input$characteristic_select_search)
+  #     
+  #   query <- input$characteristic_select_search
+  # 
+  #   if (nchar(query) > 0) {
+  #         match_type <- 'contains'
+  #         if (input$match_type_select != '') {
+  #           match_type <- input$match_type_select
+  #         }
+  #         # set the grep pattern for each match type
+  #         if (match_type == 'starts_with') {
+  #           grep_pattern <- paste0("^", query)
+  #         }
+  #         else if (match_type == 'ends_with') {
+  #           grep_pattern <- paste0(query, "$")
+  #         }
+  #         else if (match_type == 'matches') {
+  #           grep_pattern <- paste0("^", query, "$")
+  #         }
+  #         else { # contains
+  #           grep_pattern <- query
+  #         }
+  #         filtered_characteristics <- characteristic_list[grep(
+  #           grep_pattern,
+  #           characteristic_list,
+  #           ignore.case = TRUE
+  #         )]
+  #   } 
+  #   else {
+  #     filtered_characteristics <- characteristic_list
+  #   }
+  #   
+  #   # shiny::freezeReactiveValue(input, "characteristic_select_search")
+  #   
+  #   shiny::updateSelectizeInput(
+  #     session = session,
+  #     inputId = "characteristic_select",
+  #     choices = filtered_characteristics,
+  #     selected = c(input$characteristic_select, input$characteristic_select_search),
+  #     options = list(
+  #       # searchField = "value",
+  #       onType = I('
+  #            text => Shiny.setInputValue("query_data_1-characteristic_select_search", text)
+  #         '),
+  #        onBlur = I('function() { Shiny.setInputValue("query_data_1-characteristic_select_blur", true); }')
+  #     
+  #     ),      
+  #     server = TRUE
+  #   )
+  # })
     
     
     

--- a/R/mod_query_data.R
+++ b/R/mod_query_data.R
@@ -73,9 +73,14 @@ county <- utils::read.csv(
 orgs <- unique(utils::read.csv(url(
       "https://cdx.epa.gov/wqx/download/DomainValues/Organization.CSV"
     ))$ID)
-chars <- unique(utils::read.csv(url(
+
+characteristic_list <- unique(utils::read.csv(url(
       "https://cdx.epa.gov/wqx/download/DomainValues/Characteristic.CSV"
     ))$Name)
+# # this could be loaded from a local file in much less time
+# characteristic_table <- utils::read.csv("inst/Characteristic.CSV")
+# characteristic_list <- characteristic_table$Name
+
 chargroup <- unique(utils::read.csv(url(
       "https://cdx.epa.gov/wqx/download/DomainValues/CharacteristicGroup.CSV"
     ))$Name)
@@ -83,7 +88,8 @@ media <- c(
       unique(utils::read.csv(url(
         "https://cdx.epa.gov/wqx/download/DomainValues/ActivityMedia.CSV"
       ))$Name),
-      "water", "Biological Tissue", "No media"
+      # removed "water" and added code below to insert it as needed
+      "Biological Tissue", "No media"
     )
 sitetype <- c(
       unique(utils::read.csv(url(
@@ -91,9 +97,17 @@ sitetype <- c(
       ))$Name),
       "Glacier", "Aggregate water-use establishment", "Not Assigned", "Subsurface"
       )
+# these are the types of text matches used in searching the Characteristic(s) list
+match_types <- c(
+  "Starts With" = 'starts_with',
+  "Ends With" = 'ends_with',
+  "Contains" = 'contains',
+  "Equals" = 'matches'
+)
 
 mod_query_data_ui <- function(id) {
   ns <- NS(id)
+  
   tagList(
     shiny::fluidRow(
       htmltools::h3("Option A: Use example data"),
@@ -240,18 +254,33 @@ mod_query_data_ui <- function(id) {
             )
           ),
           choices = c("", media),
-          selected = c("Water", "water"),
+          selected = c("Water"), # "water" gets added automatically if Water is included.  This is for older USGS data
           multiple = TRUE
         )
       ),
       column(
         4,
-        shiny::selectizeInput(
-          ns("characteristic"),
-          "Characteristic(s)",
-          choices = NULL,
-          options = list(placeholder = "Start typing or use drop down menu"),
-          multiple = TRUE
+        shiny::fluidRow( # this is what allows both widgets to be side-by-side
+          column(width = 4,
+           shiny::selectizeInput(
+              inputId = ns("match_type_select"),
+              label = "Match type:",
+              choices = match_types, # Choices are populated on client
+              selected = 'contains',
+              multiple = FALSE
+            )
+           ),
+          column(width = 8,
+            shiny::selectizeInput(
+              ns("characteristic_select"),
+              "Characteristic(s)",
+              choices = NULL,
+              options = list(
+                  placeholder = "Start typing or use drop down menu"
+              ),
+              multiple = TRUE
+            )
+          )
         )
       ),
       column(
@@ -353,7 +382,9 @@ mod_query_data_ui <- function(id) {
 #'
 #' @noRd
 mod_query_data_server <- function(id, tadat) {
+
   shiny::moduleServer(id, function(input, output, session) {
+
     ns <- session$ns
 
     # Call the bbox map module and capture its return value
@@ -553,11 +584,27 @@ mod_query_data_server <- function(id, tadat) {
       options = list(placeholder = "Start typing or use drop down menu"),
       server = TRUE
     )
-    shiny::updateSelectizeInput(session,
-      "characteristic",
-      choices = c(chars),
+    
+    # this has custom code to allow starts_with(), ends_with(), contains(), and match() filtering
+    # browser()
+    # Set up server-side selectize
+    shiny::updateSelectizeInput(
+      session,
+      "characteristic_select",
+      choices = characteristic_list,
+
+      # there is a more robust way to get the module Id required in setInputValue()
+      # but I wasted time trying to get it working. This does work here.
+      options = list(
+        searchField = "value",
+        onType = I('
+             text => Shiny.setInputValue("query_data_1-characteristic_select_search", text)
+          ')
+      ),
       server = TRUE
     )
+    
+    
     shiny::updateSelectizeInput(session,
       "project",
       choices = c(projects),
@@ -620,6 +667,59 @@ mod_query_data_server <- function(id, tadat) {
       )
     })
 
+    # reset the server-size selectize when 'Match type' changes
+    shiny::observeEvent(input$match_type_select, {
+      shiny::updateSelectizeInput(
+        session = session,
+        inputId = "characteristic_select",
+        choices = characteristic_list,
+        server = TRUE
+      )
+    }, ignoreInit = TRUE)
+  
+  # Reactive observer to listen for changes in the selectize input text string
+  shiny::observeEvent(input$characteristic_select_search, {
+
+    query <- input$characteristic_select_search
+
+    if (nchar(query) > 0) {
+          match_type <- 'contains'
+          if (input$match_type_select != '') {
+            match_type <- input$match_type_select
+          }
+          # set the grep pattern for each match type
+          if (match_type == 'starts_with') {
+            grep_pattern <- paste0("^", query)
+          }
+          else if (match_type == 'ends_with') {
+            grep_pattern <- paste0(query, "$")
+          }
+          else if (match_type == 'matches') {
+            grep_pattern <- paste0("^", query, "$")
+          }
+          else { # contains
+            grep_pattern <- query
+          }
+          filtered_characteristics <- characteristic_list[grep(
+            grep_pattern,
+            characteristic_list,
+            ignore.case = TRUE
+          )]
+    } 
+    else {
+      filtered_characteristics <- characteristic_list
+    }
+
+    shiny::updateSelectizeInput(
+      session = session,
+      inputId = "characteristic_select",
+      choices = filtered_characteristics,
+      server = TRUE
+    )
+  })
+    
+    
+    
     # remove the modal once the dataset has been pulled
     shinybusy::remove_modal_spinner(session = shiny::getDefaultReactiveDomain())
 
@@ -669,15 +769,24 @@ mod_query_data_server <- function(id, tadat) {
       } else {
         tadat$characteristicType <- input$chargroup
       }
-      if (is.null(input$characteristic)) {
+      
+      # changed the name of the input$ variable here
+      if (is.null(input$characteristic_select)) {
         tadat$characteristicName <- "null"
       } else {
-        tadat$characteristicName <- input$characteristic
+        tadat$characteristicName <- input$characteristic_select
       }
+      
       if (is.null(input$media)) {
         tadat$sampleMedia <- "null"
       } else {
         tadat$sampleMedia <- input$media
+        
+        # "If 'Water' found in input$media then add 'water' to tadat$sampleMedia
+        # this is used for some older USGS data only
+        if (sum(grep('Water', input$media)) > 0) {
+          tadat$sampleMedia <- append(tadat$sampleMedia, 'water')
+        }
       }
       if (is.null(input$project)) {
         tadat$project <- "null"
@@ -768,8 +877,53 @@ mod_query_data_server <- function(id, tadat) {
         bBox = bbox_reactive()
       )
 
-      # Get the data summary
-      result_summary <- dataRetrieval::whatWQPdata(args_temp)
+      # added a tryCatch() to prevent ad-hoc WQX 500 errors while downloading data
+      
+      success <- FALSE # Flag to track if the process completes successfully
+            
+      tryCatch(
+        {
+          # Temporarily treat warnings as errors
+          old_warn <- options("warn")
+          options(warn = 2)
+
+          # Get the data summary
+          result_summary <- dataRetrieval::whatWQPdata(args_temp)
+
+          success <- TRUE # Set flag to true if all operations succeed
+
+          # Restore warning options
+          options(old_warn)
+        },
+        error = function(e) {
+          # Restore warning options in case of error
+          options(old_warn)
+
+          # Log error details for debugging
+          cat("Error: ", e$message, "\n")
+
+          # Show error notification to the user
+          shiny::showNotification(
+            ui = tagList(
+              htmltools::h4(htmltools::strong("WQP Error")),
+              htmltools::hr(style = "margin-top: 5px; margin-bottom: 5px;"), # Adds a separator line
+              paste(e$message),
+              paste("An error occurred while querying the Water Quality Portal.  Check your filter values and try again.")
+            ),
+            type = "error",
+            duration = NULL,
+            id = "uploadError"
+          )
+        }
+      )
+
+      # Ensure spinner is removed regardless of success or error
+      shinybusy::remove_modal_spinner(session = shiny::getDefaultReactiveDomain())
+      # end new
+      if (success == FALSE) {
+        return()
+      }
+      
 
       # Check if anything is outside the tribal's shapefile boundary
       if (inherits(tadat$tribal_boundary, "sf")) {
@@ -1012,7 +1166,7 @@ mod_query_data_server <- function(id, tadat) {
           shiny::updateSelectizeInput(session, "county", selected = tadat$countycode)
           shiny::updateSelectizeInput(session, "siteid", selected = tadat$siteid)
           shiny::updateSelectizeInput(session, "type", selected = tadat$siteType)
-          shiny::updateSelectizeInput(session, "characteristic", selected = tadat$characteristicName)
+          shiny::updateSelectizeInput(session, "characteristic_select", selected = tadat$characteristicName)
           shiny::updateSelectizeInput(session, "chargroup", selected = tadat$characteristicType)
           shiny::updateSelectizeInput(session, "media", selected = tadat$sampleMedia)
           shiny::updateSelectizeInput(session, "project", selected = tadat$project)

--- a/R/mod_review_data.R
+++ b/R/mod_review_data.R
@@ -40,21 +40,25 @@ mod_review_data_server <- function(id, tadat) {
     review_things <- shiny::reactiveValues()
 
     shiny::observeEvent(input$review_go, {
-      removals <- tadat$removals
-      sel <- which(removals == TRUE, arr.ind = TRUE)
-      # Bombing here
-      if (length(sel) > 0) {
-        removals[sel] <- names(removals)[sel[, "col"]]
-        removals[removals == FALSE] <- ""
-        tadat$raw$TADA.RemovalReason <- apply(
-          removals, 1,
-          function(row) {
-            paste(row[nzchar(row)], collapse = ", ")
-          }
-        )
-      } else {
-        tadat$raw$TADA.RemovalReason <- NA
-      }
+      
+      ## this is moved to mod_data_flagging.R and not needed here.
+      # # start this column is going to be added in the step where the removals are first applied
+      # removals <- tadat$removals
+      # sel <- which(removals == TRUE, arr.ind = TRUE)
+      # # Bombing here
+      # if (length(sel) > 0) {
+      #   removals[sel] <- names(removals)[sel[, "col"]]
+      #   removals[removals == FALSE] <- ""
+      #   tadat$raw$TADA.RemovalReason <- apply(
+      #     removals, 1,
+      #     function(row) {
+      #       paste(row[nzchar(row)], collapse = ", ")
+      #     }
+      #   )
+      # } else {
+      #   tadat$raw$TADA.RemovalReason <- NA
+      # }
+      # # end
 
       # data for bar chart - this is real rough
       step_rems <- sort_removals(tadat$removals)

--- a/tests/search_characteristics.R
+++ b/tests/search_characteristics.R
@@ -1,4 +1,10 @@
 library(shiny)
+library(shinyjs)
+
+# this snippet runs the Characteristics search using a selectable 'match type'.
+# It uses a separate 'text_input' widget to search the values
+# to simplify the reactive behavior.  It might be possible to collapse
+# the widgets and search directly in the drop-down list, but I was not able to get that to work.
 
 match_types <- c(
   "Starts With" = 'starts_with',
@@ -9,9 +15,12 @@ match_types <- c(
 characteristic_list <- unique(utils::read.csv(url(
       "https://cdx.epa.gov/wqx/download/DomainValues/Characteristic.CSV"
     ))$Name)
+# # this can be loaded from a local file in much less time
+# characteristic_table <- utils::read.csv("../inst/Characteristic.CSV")
+# characteristic_list <- characteristic_table$Name
 
 ui <- fluidPage(
-  titlePanel("Selectize 'Starts With' Filter"),
+  titlePanel("Selectize with 'Match Type' Search"),
   
   fluidRow(
       column(4,
@@ -23,88 +32,81 @@ ui <- fluidPage(
           multiple = FALSE
         )
       ),
-      column(8,
+      column(4,
+        # Input for the user to type their search string
+        textInput(
+          inputId = "text_sring", 
+          label = "Search string:", 
+          value = ""
+        )
+      ),
+      column(4,
         selectizeInput(
           inputId = "characteristic_select", 
           label = "Select one or more Characteristic:", 
           choices = NULL, 
-          multiple = TRUE
+          multiple = TRUE,
+          options = list(
+            openOnFocus = TRUE
+          )
         )
       )
   )
 )
 
 server <- function(input, output, session) {
-  # All possible choices
-  all_characteristics <- characteristic_list
-  
-  # Set up server-side selectize
-  updateSelectizeInput(
-    session = session,
-    inputId = "characteristic_select",
-    choices = all_characteristics,
-    server = TRUE,
-    options = list(
-      placeholder = "Start typing to search...",
-      # The searchField option allows customization of the search behavior,
-      # but for a simple list, the default behavior is sufficient for 'starts with'.
-      searchField = "value",
-      onType = I('
-           text => Shiny.setInputValue("characteristic_select_search", text)
-        ')
-    )
-  )
-  
-  # reset the server-size selectize when 'Match type' changes
-  observeEvent(input$match_type_selector, {
-      updateSelectizeInput(
-        session = session,
-        inputId = "characteristic_select",
-        choices = characteristic_list,
-        server = TRUE
+
+  # A reactive expression that filters the choices based on the input pattern
+  filtered_list <- reactive({
+    text_sring <- input$text_sring
+    if (text_sring == "") {
+      # If the text string is empty, return all choices
+      return(characteristic_list)
+    } 
+    else {
+      match_type <- 'contains'
+      if (input$match_type_selector != '') {
+        match_type = input$match_type_selector
+      }
+      # set the grep pattern for each match type
+      if (match_type == 'starts_with') {
+        grep_pattern <- paste0("^", text_sring)
+      }
+      else if (match_type == 'ends_with') {
+        grep_pattern <- paste0(text_sring, "$")
+      }
+      else if (match_type == 'matches') {
+        grep_pattern <- paste0("^", text_sring, "$")
+      }
+      else { # contains
+        grep_pattern <- text_sring
+      }
+      return(characteristic_list[grep(
+                                      grep_pattern,
+                                      characteristic_list,
+                                      ignore.case = TRUE
+                                    )
+                                 ]
       )
-  }, ignoreInit = TRUE)
-  
-  # Reactive observer to listen for changes in the selectize input text string
-  observeEvent(input$characteristic_select_search, {
-    query <- input$characteristic_select_search
-    
-    if (nchar(query) > 0) {
-          match_type <- 'contains'
-          if (input$match_type_selector != '') {
-            match_type = input$match_type_selector
-          }
-          # set the grep pattern for each match type
-          if (match_type == 'starts_with') {
-            grep_pattern <- paste0("^", query)
-          }
-          else if (match_type == 'ends_with') {
-            grep_pattern <- paste0(query, "$")
-          }
-          else if (match_type == 'matches') {
-            grep_pattern <- paste0("^", query, "$")
-          }
-          else { # contains
-            grep_pattern <- query
-          }
-          filtered_characteristics <- all_characteristics[grep(
-            grep_pattern,
-            all_characteristics,
-            ignore.case = TRUE
-          )]
-    } else {
-      filtered_characteristics <- all_characteristics
     }
+  })
+  
+  # Observer to update the selectizeInput choices whenever the filtered_list changes
+  observe({
+    # using isolate() here is key to this whole thing working.
+    # the value would be subject to an event when the updateSelectizeInput() happens below,
+    # so you need to 'isolate' the current value before you run the update
+    previous_selected <- isolate(input$characteristic_select)
     
     updateSelectizeInput(
-      session = session,
-      inputId = "characteristic_select",
-      choices = filtered_characteristics,
-      server = TRUE
+      session,
+      "characteristic_select",
+      choices = c(filtered_list(), previous_selected),
+      server = TRUE,
+      selected = previous_selected
     )
-    
-  }, ignoreInit = TRUE)
-  
-} # end server function
+  })
+}
+
 
 shinyApp(ui, server)

--- a/tests/search_characteristics.R
+++ b/tests/search_characteristics.R
@@ -1,0 +1,110 @@
+library(shiny)
+
+match_types <- c(
+  "Starts With" = 'starts_with',
+  "Ends With" = 'ends_with',
+  "Contains" = 'contains',
+  "Equals" = 'matches'
+)
+characteristic_list <- unique(utils::read.csv(url(
+      "https://cdx.epa.gov/wqx/download/DomainValues/Characteristic.CSV"
+    ))$Name)
+
+ui <- fluidPage(
+  titlePanel("Selectize 'Starts With' Filter"),
+  
+  fluidRow(
+      column(4,
+         selectizeInput(
+          inputId = "match_type_selector",
+          label = "Match type:",
+          choices = match_types, # Choices are populated on client
+          selected = 'contains',
+          multiple = FALSE
+        )
+      ),
+      column(8,
+        selectizeInput(
+          inputId = "characteristic_select", 
+          label = "Select one or more Characteristic:", 
+          choices = NULL, 
+          multiple = TRUE
+        )
+      )
+  )
+)
+
+server <- function(input, output, session) {
+  # All possible choices
+  all_characteristics <- characteristic_list
+  
+  # Set up server-side selectize
+  updateSelectizeInput(
+    session = session,
+    inputId = "characteristic_select",
+    choices = all_characteristics,
+    server = TRUE,
+    options = list(
+      placeholder = "Start typing to search...",
+      # The searchField option allows customization of the search behavior,
+      # but for a simple list, the default behavior is sufficient for 'starts with'.
+      searchField = "value",
+      onType = I('
+           text => Shiny.setInputValue("characteristic_select_search", text)
+        ')
+    )
+  )
+  
+  # reset the server-size selectize when 'Match type' changes
+  observeEvent(input$match_type_selector, {
+      updateSelectizeInput(
+        session = session,
+        inputId = "characteristic_select",
+        choices = characteristic_list,
+        server = TRUE
+      )
+  }, ignoreInit = TRUE)
+  
+  # Reactive observer to listen for changes in the selectize input text string
+  observeEvent(input$characteristic_select_search, {
+    query <- input$characteristic_select_search
+    
+    if (nchar(query) > 0) {
+          match_type <- 'contains'
+          if (input$match_type_selector != '') {
+            match_type = input$match_type_selector
+          }
+          # set the grep pattern for each match type
+          if (match_type == 'starts_with') {
+            grep_pattern <- paste0("^", query)
+          }
+          else if (match_type == 'ends_with') {
+            grep_pattern <- paste0(query, "$")
+          }
+          else if (match_type == 'matches') {
+            grep_pattern <- paste0("^", query, "$")
+          }
+          else { # contains
+            grep_pattern <- query
+          }
+          filtered_characteristics <- all_characteristics[grep(
+            grep_pattern,
+            all_characteristics,
+            ignore.case = TRUE
+          )]
+    } else {
+      filtered_characteristics <- all_characteristics
+    }
+    
+    updateSelectizeInput(
+      session = session,
+      inputId = "characteristic_select",
+      choices = filtered_characteristics,
+      server = TRUE
+    )
+    
+  }, ignoreInit = TRUE)
+  
+} # end server function
+
+shinyApp(ui, server)


### PR DESCRIPTION
1. https://github.com/USEPA/TADAShiny/issues/144 - add search match drop down (Equals, Starts with, Ends with, Contains).  Default to "Contains"
    **This is still in progress.  There is a working sample of how I can get it working in tests/search_characteristics.R
	If the 3 widget solution is okay, I can bring it into TADAShiny in the next set of commmits.**
	
2. https://github.com/USEPA/TADAShiny/issues/217 - include TADA.RemovalReason in dataset exports except FINAL (clean)
    Moved the creation of TADA.RemovalReason into mod_data_flagging.R so it is always available in working dataset.
	
3. https://github.com/USEPA/TADAShiny/issues/237 - fix bug where Overview tab auto-switches to Load tab on web application (does not happen in development env)
    Figured out that we needed a CSS directive 'pointer-events: none;' to prevent the reload which occurred anytime a user clicked a 'disabled' anchor
	
4. https://github.com/USEPA/TADAShiny/issues/241 - adhoc fix in code to search using 'Water' and 'water' so users don't need to know the subtlety
	Hid the complexity from the user and insered the lower-case 'water' in the search in the backend.
	
5. https://github.com/USEPA/TADAShiny/issues/255 - do not include TADA.RemovalReason [or TADA.Remove] in FINAL (clean) dataset exports.  It is always "FALSE"
    removed the columns in the code that generates the FINAL (clean) dataset.