### PR TITLE
fix UI bug preventing filters from being removed properly

### DIFF
--- a/R/mod_filter.R
+++ b/R/mod_filter.R
@@ -511,7 +511,7 @@ mod_filtering_server <- function(id, tadat) {
 
     # button: Reset all Filters
     shiny::observeEvent(input$removeAllFilters, {
-      # remove row filters added via tadat$selected_filters
+      # remove all row filters added via tadat$selected_filters
       for (fld in unique(tadat$selected_filters$Fields)) {
         if (!(fld %in% names(tadat$raw))) next
 
@@ -521,16 +521,6 @@ mod_filtering_server <- function(id, tadat) {
         if (length(drop_idx) > 0) {
           tadat$removals <- tadat$removals[, -drop_idx, drop = FALSE]
         }
-
-        field_filters <- tadat$selected_filters[tadat$selected_filters$Fields == fld, , drop = FALSE]
-        data_labels <- labelize(tadat$raw[[fld]])
-        sel_labels <- unique(field_filters$Value)
-
-        to_remove <- data_labels %in% sel_labels
-        all_vals <- paste(sel_labels, collapse = " or ")
-        label <- paste0(prefix, "Exclude ", fld, " is ", all_vals)
-
-        tadat$removals[[label]] <- as.logical(to_remove)
       }
 
       tadat$selected_filters <- data.frame(

--- a/R/mod_filter.R
+++ b/R/mod_filter.R
@@ -84,8 +84,18 @@ mod_filtering_server <- function(id, tadat) {
     values <- shiny::reactiveValues()
     values$selected_field <- NULL # this holds the selected row in the 'Selected filters' table
 
-    filter_dat <- readRDS(system.file("extdata", "filter_descriptions.rds", package = "TADAShiny"))
-
+    # Include tryCatch and file check
+    filter_dat <- tryCatch({
+      fp <- system.file("extdata", "filter_descriptions.rds", package = "TADAShiny")
+      if (!nzchar(fp) || !file.exists(fp)) {
+        data.frame(Fields = character(), Description = character(), stringsAsFactors = FALSE)
+      } else {
+        readRDS(fp)
+      }
+    }, error = function(e) {
+      data.frame(Fields = character(), Description = character(), stringsAsFactors = FALSE)
+    })
+    
     # Prefix for module-generated removals
     prefix <- "Filter (module): "
 
@@ -105,6 +115,19 @@ mod_filtering_server <- function(id, tadat) {
       chr[is_missing] <- na_label
       chr
     }
+    
+    # Robust logical converter (fix TADA.Remove and removals columns)
+    to_logical <- function(x) {
+      if (is.logical(x)) return(x)
+      if (is.numeric(x)) return(x != 0)
+      x_chr <- trimws(tolower(as.character(x)))
+      true_vals  <- c("true", "t", "1", "yes", "y")
+      false_vals <- c("false", "f", "0", "no", "n", "")
+      res <- rep(NA, length(x_chr))
+      res[x_chr %in% true_vals]  <- TRUE
+      res[x_chr %in% false_vals] <- FALSE
+      res
+    }
 
     # Keep mask honoring TADA.Remove and all removals; optionally ignore this field's own removal columns
     keep_mask_for <- function(fld = NULL) {
@@ -116,16 +139,21 @@ mod_filtering_server <- function(id, tadat) {
       # TADA.Remove mask
       keep_tada <- rep(TRUE, nrow(d))
       if ("TADA.Remove" %in% names(d)) {
-        rmv <- suppressWarnings(as.logical(d$TADA.Remove))
+        rmv <- to_logical(d$TADA.Remove)
         rmv[is.na(rmv)] <- FALSE
         keep_tada <- !rmv
       }
 
+      # Removals coercion
       rem <- tadat$removals
       if (!is.data.frame(rem) || ncol(rem) == 0 || nrow(rem) != nrow(d)) {
         keep_rem <- rep(TRUE, nrow(d))
       } else {
-        rem <- as.data.frame(lapply(rem, function(col) if (is.logical(col)) col else as.logical(col)))
+        rem <- as.data.frame(lapply(rem, function(col) {
+          lc <- to_logical(col)
+          lc[is.na(lc)] <- FALSE
+          lc
+        }))
         if (!is.null(fld)) {
           prefixes <- c(
             paste0("Filter (module): Exclude ", fld, " is "),
@@ -136,7 +164,7 @@ mod_filtering_server <- function(id, tadat) {
         }
         keep_rem <- if (ncol(rem) == 0) rep(TRUE, nrow(d)) else rowSums(rem, na.rm = TRUE) == 0
       }
-
+      
       keep_tada & keep_rem
     }
 
@@ -404,7 +432,7 @@ mod_filtering_server <- function(id, tadat) {
       }
       
       # Selected labels (already labelized via filter_values -> getValues -> labelize)
-      vals <- isolate(filter_values())
+      vals <- shiny::isolate(filter_values())
       selected_labels <- unique(vals$Value_label[rows])
       
       # Universe: ALL labels in raw for this field (labelized), not just those kept by other filters
@@ -467,7 +495,7 @@ mod_filtering_server <- function(id, tadat) {
       }
       
       # Get selected labels (labelized)
-      vals <- isolate(filter_values())
+      vals <- shiny::isolate(filter_values())
       selected_labels <- unique(vals$Value_label[rows])
       
       # Merge with existing excludes for this field
@@ -521,14 +549,18 @@ mod_filtering_server <- function(id, tadat) {
     # button: Reset all Filters
     shiny::observeEvent(input$removeAllFilters, {
       # remove all row filters added via tadat$selected_filters
-      for (fld in unique(tadat$selected_filters$Fields)) {
-        if (!(fld %in% names(tadat$raw))) next
-
-        # Drop this field's prior module columns
-        prior_prefix <- paste0(prefix, "Exclude ", fld, " is ")
-        drop_idx <- which(startsWith(colnames(tadat$removals), prior_prefix))
-        if (length(drop_idx) > 0) {
-          tadat$removals <- tadat$removals[, -drop_idx, drop = FALSE]
+      if (is.data.frame(tadat$removals) &&
+          nrow(tadat$removals) == nrow(tadat$raw) &&
+          ncol(tadat$removals) > 0) {
+        for (fld in unique(tadat$selected_filters$Fields)) {
+          if (!(fld %in% names(tadat$raw))) next
+          
+          # Drop this field's prior module columns
+          prior_prefix <- paste0(prefix, "Exclude ", fld, " is ")
+          drop_idx <- which(startsWith(colnames(tadat$removals), prior_prefix))
+          if (length(drop_idx) > 0) {
+            tadat$removals <- tadat$removals[, -drop_idx, drop = FALSE]
+          }
         }
       }
       
@@ -545,8 +577,12 @@ mod_filtering_server <- function(id, tadat) {
       if (is.data.frame(tadat$removals) &&
           nrow(tadat$removals) == nrow(tadat$raw) &&
           ncol(tadat$removals) > 0) {
-        rem_log <- as.data.frame(lapply(tadat$removals, function(col)
-          if (is.logical(col)) col else as.logical(col)))
+        # use to_logical when computing TADA.RemovalReason so NA is handled consistently
+        rem_log <- as.data.frame(lapply(tadat$removals, function(col) {
+          lc <- to_logical(col)
+          lc[is.na(lc)] <- FALSE
+          lc
+        }))
         cn <- colnames(rem_log)
         mat <- as.matrix(rem_log)
         any_true <- rowSums(mat, na.rm = TRUE) > 0
@@ -627,23 +663,24 @@ mod_filtering_server <- function(id, tadat) {
 
               for (fld in unique(tadat$selected_filters$Fields)) {
                 if (!(fld %in% names(tadat$raw))) next
-
+                
                 # Drop this field's prior module columns
                 prior_prefix <- paste0(prefix, "Exclude ", fld, " is ")
                 drop_idx <- which(startsWith(colnames(tadat$removals), prior_prefix))
                 if (length(drop_idx) > 0) {
                   tadat$removals <- tadat$removals[, -drop_idx, drop = FALSE]
                 }
-
+                
                 field_filters <- tadat$selected_filters[tadat$selected_filters$Fields == fld, , drop = FALSE]
                 data_labels <- labelize(tadat$raw[[fld]])
                 sel_labels <- unique(field_filters$Value)
-
+                
                 to_remove <- data_labels %in% sel_labels
                 all_vals <- paste(sel_labels, collapse = " or ")
                 label <- paste0(prefix, "Exclude ", fld, " is ", all_vals)
-
-                tadat$removals[[label]] <- as.logical(to_remove)
+                
+                # to_remove is already logical
+                tadat$removals[[label]] <- to_remove
               }
             } else {
               # Drop ALL module-generated removal columns (current and legacy prefixes)
@@ -665,8 +702,12 @@ mod_filtering_server <- function(id, tadat) {
             if (is.data.frame(removals_df) &&
               nrow(removals_df) == nrow(tadat$raw) &&
               ncol(removals_df) > 0) {
-              # Coerce to logical to avoid surprises
-              rem_log <- as.data.frame(lapply(removals_df, function(col) if (is.logical(col)) col else as.logical(col)))
+              # Use robust to_logical converter to avoid surprises
+              rem_log <- as.data.frame(lapply(removals_df, function(col) {
+                lc <- to_logical(col)
+                lc[is.na(lc)] <- FALSE
+                lc
+              }))
               cn <- colnames(rem_log)
               mat <- as.matrix(rem_log)
 

--- a/R/mod_filter.R
+++ b/R/mod_filter.R
@@ -95,7 +95,7 @@ mod_filtering_server <- function(id, tadat) {
     }, error = function(e) {
       data.frame(Fields = character(), Description = character(), stringsAsFactors = FALSE)
     })
-    
+
     # Prefix for module-generated removals
     prefix <- "Filter (module): "
 
@@ -115,7 +115,7 @@ mod_filtering_server <- function(id, tadat) {
       chr[is_missing] <- na_label
       chr
     }
-    
+
     # Robust logical converter (fix TADA.Remove and removals columns)
     to_logical <- function(x) {
       if (is.logical(x)) return(x)
@@ -164,7 +164,7 @@ mod_filtering_server <- function(id, tadat) {
         }
         keep_rem <- if (ncol(rem) == 0) rep(TRUE, nrow(d)) else rowSums(rem, na.rm = TRUE) == 0
       }
-      
+
       keep_tada & keep_rem
     }
 
@@ -420,7 +420,7 @@ mod_filtering_server <- function(id, tadat) {
         ))
         return(invisible(NULL))
       }
-      
+
       # Determine selected rows
       if (is.null(rows)) rows <- input$filterStep2_rows_selected
       if (is.null(rows) || length(rows) == 0) {
@@ -430,11 +430,11 @@ mod_filtering_server <- function(id, tadat) {
         ))
         return(invisible(NULL))
       }
-      
+
       # Selected labels (already labelized via filter_values -> getValues -> labelize)
       vals <- shiny::isolate(filter_values())
       selected_labels <- unique(vals$Value_label[rows])
-      
+
       # Universe: ALL labels in raw for this field (labelized), not just those kept by other filters
       base <- tadat$raw
       if (is.null(base) || !(fld %in% names(base))) {
@@ -445,13 +445,13 @@ mod_filtering_server <- function(id, tadat) {
         return(invisible(NULL))
       }
       all_labels <- unique(labelize(base[[fld]]))
-      
+
       # Complement = everything except the selected labels
       complement_labels <- setdiff(all_labels, selected_labels)
-      
+
       # Replace any existing filters for this field, then store complement as 'Exclude' rows
       tadat$selected_filters <- tadat$selected_filters[!(tadat$selected_filters$Fields == fld), , drop = FALSE]
-      
+
       if (length(complement_labels) > 0) {
         new_rows <- data.frame(
           Fields = rep(fld, length(complement_labels)),
@@ -466,7 +466,7 @@ mod_filtering_server <- function(id, tadat) {
           .keep_all = TRUE
         )
       }
-      
+
       shiny::showNotification(
         sprintf("Applied 'Include Only' to %d value(s) for %s", length(selected_labels), fld),
         type = "message", duration = 3
@@ -483,7 +483,7 @@ mod_filtering_server <- function(id, tadat) {
         ))
         return(invisible(NULL))
       }
-      
+
       # Determine selected rows
       if (is.null(rows)) rows <- input$filterStep2_rows_selected
       if (is.null(rows) || length(rows) == 0) {
@@ -493,19 +493,19 @@ mod_filtering_server <- function(id, tadat) {
         ))
         return(invisible(NULL))
       }
-      
+
       # Get selected labels (labelized)
       vals <- shiny::isolate(filter_values())
       selected_labels <- unique(vals$Value_label[rows])
-      
+
       # Merge with existing excludes for this field
       existing_field <- tadat$selected_filters[tadat$selected_filters$Fields == fld, , drop = FALSE]
       existing_vals <- if (nrow(existing_field) > 0) unique(existing_field$Value) else character(0)
       updated_excluded_vals <- sort(unique(c(existing_vals, selected_labels)))
-      
+
       # Remove prior rows for this field and add updated
       tadat$selected_filters <- tadat$selected_filters[tadat$selected_filters$Fields != fld, , drop = FALSE]
-      
+
       if (length(updated_excluded_vals) > 0) {
         new_rows <- data.frame(
           Fields = rep(fld, length(updated_excluded_vals)),
@@ -520,7 +520,7 @@ mod_filtering_server <- function(id, tadat) {
           .keep_all = TRUE
         )
       }
-      
+
       shiny::showNotification(
         sprintf("Excluded %d value(s) for %s", length(selected_labels), fld),
         type = "message", duration = 3
@@ -550,11 +550,11 @@ mod_filtering_server <- function(id, tadat) {
     shiny::observeEvent(input$removeAllFilters, {
       # remove all row filters added via tadat$selected_filters
       if (is.data.frame(tadat$removals) &&
-          nrow(tadat$removals) == nrow(tadat$raw) &&
-          ncol(tadat$removals) > 0) {
+        nrow(tadat$removals) == nrow(tadat$raw) &&
+        ncol(tadat$removals) > 0) {
         for (fld in unique(tadat$selected_filters$Fields)) {
           if (!(fld %in% names(tadat$raw))) next
-          
+
           # Drop this field's prior module columns
           prior_prefix <- paste0(prefix, "Exclude ", fld, " is ")
           drop_idx <- which(startsWith(colnames(tadat$removals), prior_prefix))
@@ -563,7 +563,7 @@ mod_filtering_server <- function(id, tadat) {
           }
         }
       }
-      
+
       # Clear all selected filters
       tadat$selected_filters <- data.frame(
         Fields = character(),
@@ -572,11 +572,11 @@ mod_filtering_server <- function(id, tadat) {
         Count = integer(),
         stringsAsFactors = FALSE
       )
-      
+
       # Recompute TADA.RemovalReason for remaining removals (if any)
       if (is.data.frame(tadat$removals) &&
-          nrow(tadat$removals) == nrow(tadat$raw) &&
-          ncol(tadat$removals) > 0) {
+        nrow(tadat$removals) == nrow(tadat$raw) &&
+        ncol(tadat$removals) > 0) {
         # use to_logical when computing TADA.RemovalReason so NA is handled consistently
         rem_log <- as.data.frame(lapply(tadat$removals, function(col) {
           lc <- to_logical(col)
@@ -596,7 +596,7 @@ mod_filtering_server <- function(id, tadat) {
       } else {
         tadat$raw$TADA.RemovalReason <- NA_character_
       }
-      
+
       shinyjs::hide("includeOnlySelectedValues")
       shinyjs::hide("excludeSelectedValues")
     })
@@ -663,22 +663,22 @@ mod_filtering_server <- function(id, tadat) {
 
               for (fld in unique(tadat$selected_filters$Fields)) {
                 if (!(fld %in% names(tadat$raw))) next
-                
+
                 # Drop this field's prior module columns
                 prior_prefix <- paste0(prefix, "Exclude ", fld, " is ")
                 drop_idx <- which(startsWith(colnames(tadat$removals), prior_prefix))
                 if (length(drop_idx) > 0) {
                   tadat$removals <- tadat$removals[, -drop_idx, drop = FALSE]
                 }
-                
+
                 field_filters <- tadat$selected_filters[tadat$selected_filters$Fields == fld, , drop = FALSE]
                 data_labels <- labelize(tadat$raw[[fld]])
                 sel_labels <- unique(field_filters$Value)
-                
+
                 to_remove <- data_labels %in% sel_labels
                 all_vals <- paste(sel_labels, collapse = " or ")
                 label <- paste0(prefix, "Exclude ", fld, " is ", all_vals)
-                
+
                 # to_remove is already logical
                 tadat$removals[[label]] <- to_remove
               }
@@ -686,11 +686,11 @@ mod_filtering_server <- function(id, tadat) {
               # Drop ALL module-generated removal columns (current and legacy prefixes)
               prefixes <- c(paste0(prefix, "Exclude "), "Filter: Exclude ")
               if (is.data.frame(tadat$removals) &&
-                  nrow(tadat$removals) == nrow(tadat$raw) &&
-                  ncol(tadat$removals) > 0) {
+                nrow(tadat$removals) == nrow(tadat$raw) &&
+                ncol(tadat$removals) > 0) {
                 drop_idx <- vapply(colnames(tadat$removals),
-                                   function(nm) any(startsWith(nm, prefixes)),
-                                   logical(1))
+                  function(nm) any(startsWith(nm, prefixes)),
+                  logical(1))
                 tadat$removals <- tadat$removals[, !drop_idx, drop = FALSE]
               }
               shinyjs::disable("removeAllFilters")

--- a/R/mod_load.R
+++ b/R/mod_load.R
@@ -909,7 +909,7 @@ mod_query_data_server <- function(id, tadat) {
           dplyr::mutate(group = MESS::cumsumbinning(
             x = tot_n,
             threshold = maxrecs,
-            maxgroupsize = 300
+            maxgroupsize = 100 # changed from 300 after hitting error HTTP 413 Payload Too Large.
           ))
 
         smallsites_list <- list()
@@ -934,28 +934,12 @@ mod_query_data_server <- function(id, tadat) {
 
             args_temp_small[["siteid"]] <- small_site_chunk
 
-            # Download the result data
-            smallsites_result_temp <- dataRetrieval::readWQPdata(args_temp_small,
-              dataProfile = "resultPhysChem",
+            # Download the WQP data using the WQX3 and the full Physical Chemistry profile
+            TADAprofile_smallsites_temp <- dataRetrieval::readWQPdata(args_temp_small,
+              service = 'ResultWQX3',
+              dataProfile = "fullPhysChem",
               ignore_attributes = TRUE
             )
-
-            # Download the site data
-            smallsites_site_temp <- dataRetrieval::whatWQPsites(args_temp_small)
-
-            # Download the project data
-            smallsites_project_temp <- dataRetrieval::readWQPdata(args_temp_small,
-              service = "Project",
-              ignore_attributes = TRUE
-            )
-
-            # Create TADA data frame
-            TADAprofile_smallsites_temp <- EPATADA::TADA_JoinWQPProfiles(
-              FullPhysChem = smallsites_result_temp,
-              Sites = smallsites_site_temp,
-              Projects = smallsites_project_temp
-            ) |>
-              dplyr::mutate(dplyr::across(tidyselect::everything(), as.character))
 
             # Assign the data to the list
             smallsites_list[[i]] <- TADAprofile_smallsites_temp
@@ -965,8 +949,10 @@ mod_query_data_server <- function(id, tadat) {
         # Combine the data
         TADA_smallsites <- dplyr::bind_rows(smallsites_list)
 
+        TADA_smallsites_legacynames <- EPATADA::TADA_RenametoLegacy(TADA_smallsites)
+        
         # Apply TADA_autoclean
-        TADA_smallsites_clean <- EPATADA::TADA_AutoClean(TADA_smallsites) |>
+        TADA_smallsites_clean <- EPATADA::TADA_AutoClean(TADA_smallsites_legacynames) |>
           dplyr::mutate(dplyr::across(tidyselect::everything(), as.character))
       } else {
         TADA_smallsites_clean <- TADA_download_temp
@@ -979,7 +965,7 @@ mod_query_data_server <- function(id, tadat) {
         bsitesvec <- unique(bigsites$MonitoringLocationIdentifier)
 
         big_title <- base::paste0(
-          "Downloading data from sites with greater than ", pretty_maxrecs,
+          "Downloading data from ", nrow(bigsites), " sites with greater than ", pretty_maxrecs,
           " results."
         )
 
@@ -993,28 +979,12 @@ mod_query_data_server <- function(id, tadat) {
 
             args_temp_big[["siteid"]] <- bsitesvec[i]
 
-            # Download the result data
-            bigsites_result_temp <- dataRetrieval::readWQPdata(args_temp_big,
-              dataProfile = "resultPhysChem",
+            # Download the WQP data using the WQX3 using the new profile
+            TADAprofile_bigsites_temp <- dataRetrieval::readWQPdata(args_temp_big,
+              service = 'ResultWQX3',
+              dataProfile = "fullPhysChem",
               ignore_attributes = TRUE
             )
-
-            # Download the site data
-            bigsites_site_temp <- dataRetrieval::whatWQPsites(args_temp_big)
-
-            # Download the project data
-            bigsites_project_temp <- dataRetrieval::readWQPdata(args_temp_big,
-              service = "Project",
-              ignore_attributes = TRUE
-            )
-
-            # Create TADA data frame
-            TADAprofile_bigsites_temp <- EPATADA::TADA_JoinWQPProfiles(
-              FullPhysChem = bigsites_result_temp,
-              Sites = bigsites_site_temp,
-              Projects = bigsites_project_temp
-            ) |>
-              dplyr::mutate(dplyr::across(tidyselect::everything(), as.character))
 
             # Assign the data to the list
             bigsites_list[[i]] <- TADAprofile_bigsites_temp
@@ -1024,8 +994,11 @@ mod_query_data_server <- function(id, tadat) {
         # Combine the data
         TADA_bigsites <- dplyr::bind_rows(bigsites_list)
 
+        # change the column names to use the 'legacy names'
+        TADA_bigsites_legacynames <- EPATADA::TADA_RenametoLegacy(TADA_bigsites)
+        
         # Apply TADA_autoclean
-        TADA_bigsites_clean <- EPATADA::TADA_AutoClean(TADA_bigsites) |>
+        TADA_bigsites_clean <- EPATADA::TADA_AutoClean(TADA_bigsites_legacynames) |>
           dplyr::mutate(dplyr::across(tidyselect::everything(), as.character))
       } else {
         TADA_bigsites_clean <- TADA_download_temp

--- a/R/mod_load.R
+++ b/R/mod_load.R
@@ -1005,7 +1005,7 @@ mod_query_data_server <- function(id, tadat) {
 
             # Download the WQP data using the WQX3 and the full Physical Chemistry profile
             TADAprofile_smallsites_temp <- dataRetrieval::readWQPdata(args_temp_small,
-              service = 'ResultWQX3',
+              service = "ResultWQX3",
               dataProfile = "fullPhysChem",
               ignore_attributes = TRUE
             )
@@ -1019,7 +1019,7 @@ mod_query_data_server <- function(id, tadat) {
         TADA_smallsites <- dplyr::bind_rows(smallsites_list)
 
         TADA_smallsites_legacynames <- EPATADA::TADA_RenametoLegacy(TADA_smallsites)
-        
+
         # Apply TADA_autoclean
         TADA_smallsites_clean <- EPATADA::TADA_AutoClean(TADA_smallsites_legacynames) |>
           dplyr::mutate(dplyr::across(tidyselect::everything(), as.character))
@@ -1050,7 +1050,7 @@ mod_query_data_server <- function(id, tadat) {
 
             # Download the WQP data using the WQX3 using the new profile
             TADAprofile_bigsites_temp <- dataRetrieval::readWQPdata(args_temp_big,
-              service = 'ResultWQX3',
+              service = "ResultWQX3",
               dataProfile = "fullPhysChem",
               ignore_attributes = TRUE
             )
@@ -1065,7 +1065,7 @@ mod_query_data_server <- function(id, tadat) {
 
         # change the column names to use the 'legacy names'
         TADA_bigsites_legacynames <- EPATADA::TADA_RenametoLegacy(TADA_bigsites)
-        
+
         # Apply TADA_autoclean
         TADA_bigsites_clean <- EPATADA::TADA_AutoClean(TADA_bigsites_legacynames) |>
           dplyr::mutate(dplyr::across(tidyselect::everything(), as.character))

--- a/tests/testthat/test-mod_filter.R
+++ b/tests/testthat/test-mod_filter.R
@@ -31,59 +31,59 @@ wait_until <- function(expr, session, timeout_ms = 6000, step_ms = 25) {
 
 test_that("'Remove All Filters' clears per-field removals and restores Step 2 values", {
   skip_on_cran()
-  
+
   d <- tiny_data()
   tadat <- new_tadat(d)
   prefix <- "Filter (module): "
-  
+
   testServer(mod_filtering_server, args = list(tadat = tadat), {
     values$selected_field <- "FieldA"
     session$flushReact()
-    
+
     vals0 <- shiny::isolate(filter_values())
     expect_true("x" %in% vals0$Value_label)
     baseline_x <- vals0$Count[match("x", vals0$Value_label)]
     expect_true(is.finite(baseline_x))
     expect_gt(baseline_x, 0)
-    
+
     i_x <- which(vals0$Value_label == "x")
     add_filters_exclude(rows = i_x)
     session$flushReact()
-    
+
     expect_gt(nrow(shiny::isolate(tadat$selected_filters)), 0)
-    
+
     ok <- wait_until(
       expr = function() any(startsWith(colnames(tadat$removals), paste0(prefix, "Exclude FieldA"))),
       session = session
     )
     expect_true(ok)
-    
+
     cn <- colnames(shiny::isolate(tadat$removals))
     colname_before <- cn[startsWith(cn, paste0(prefix, "Exclude FieldA"))]
     expect_gte(length(colname_before), 1)
-    
+
     vals1 <- shiny::isolate(filter_values())
     if ("x" %in% vals1$Value_label) {
       expect_equal(vals1$Count[match("x", vals1$Value_label)], 0)
     } else {
       expect_false("x" %in% vals1$Value_label)
     }
-    
+
     session$setInputs(removeAllFilters = 1)
     session$flushReact()
-    
+
     ok2 <- wait_until(
       expr = function() !any(startsWith(colnames(tadat$removals), paste0(prefix, "Exclude FieldA"))),
       session = session
     )
     expect_true(ok2)
-    
+
     vals2 <- shiny::isolate(filter_values())
     expect_true("x" %in% vals2$Value_label)
     expect_equal(vals2$Count[match("x", vals2$Value_label)], baseline_x)
-    
+
     expect_equal(nrow(shiny::isolate(tadat$selected_filters)), 0)
-    
+
     reasons <- shiny::isolate(tadat$raw$TADA.RemovalReason)
     expect_equal(length(reasons), nrow(tadat$raw))
     expect_true(all(is.na(reasons)))
@@ -92,43 +92,43 @@ test_that("'Remove All Filters' clears per-field removals and restores Step 2 va
 
 test_that("Exclude and Include Only update selected_filters and per-field removals correctly", {
   skip_on_cran()
-  
+
   d <- tiny_data()
   tadat <- new_tadat(d)
   prefix <- "Filter (module): "
-  
+
   testServer(mod_filtering_server, args = list(tadat = tadat), {
     values$selected_field <- "FieldA"
     session$flushReact()
-    
+
     vals <- shiny::isolate(filter_values())
     i_x  <- which(vals$Value_label == "x")
     i_na <- which(vals$Value_label == "NA - Not Available")
-    
+
     add_filters_exclude(rows = i_x)
     session$flushReact()
     expect_gt(nrow(shiny::isolate(tadat$selected_filters)), 0)
-    
+
     ok <- wait_until(
       expr = function() any(startsWith(colnames(tadat$removals), paste0(prefix, "Exclude FieldA"))),
       session = session
     )
     expect_true(ok)
-    
+
     sf1 <- shiny::isolate(tadat$selected_filters)
     expect_true(nrow(sf1) >= 1)
     expect_true(all(sf1$Filter == "Exclude"))
     expect_true("x" %in% sf1$Value)
-    
+
     cn <- colnames(shiny::isolate(tadat$removals))
     colname <- cn[startsWith(cn, paste0(prefix, "Exclude FieldA"))]
     expect_gte(length(colname), 1)
     expect_true(any(shiny::isolate(tadat$removals[[colname[1]]]), na.rm = TRUE))
-    
+
     add_filters_include_only(rows = i_na)
     session$flushReact()
     expect_gt(nrow(shiny::isolate(tadat$selected_filters)), 0)
-    
+
     ok2 <- wait_until(
       expr = function() nrow(tadat$selected_filters) > 0 &&
         all(tadat$selected_filters$Fields == "FieldA") &&
@@ -136,17 +136,17 @@ test_that("Exclude and Include Only update selected_filters and per-field remova
       session = session
     )
     expect_true(ok2)
-    
+
     sf2 <- shiny::isolate(tadat$selected_filters)
     expect_false("NA - Not Available" %in% sf2$Value)
-    
+
     ok3 <- wait_until(
       expr = function() is.character(tadat$raw$TADA.RemovalReason) &&
         length(tadat$raw$TADA.RemovalReason) == nrow(tadat$raw),
       session = session
     )
     expect_true(ok3)
-    
+
     reasons <- shiny::isolate(tadat$raw$TADA.RemovalReason)
     expect_true(any(is.na(reasons)))
     expect_true(any(!is.na(reasons)))
@@ -155,43 +155,43 @@ test_that("Exclude and Include Only update selected_filters and per-field remova
 
 test_that("Labelization aggregates NA-like values and pie source reflects applied removals", {
   skip_on_cran()
-  
+
   d <- tiny_data()
   tadat <- new_tadat(d)
   prefix <- "Filter (module): "
-  
+
   testServer(mod_filtering_server, args = list(tadat = tadat), {
     values$selected_field <- "FieldA"
     session$flushReact()
-    
+
     # Baseline: labelization aggregates NA-like values
     vals <- shiny::isolate(filter_values())
     expect_true("NA - Not Available" %in% vals$Value_label)
     na_count <- vals$Count[match("NA - Not Available", vals$Value_label)]
     expect_gte(na_count, 3)
-    
+
     # Baseline count for "x" from active data (honors TADA.Remove)
     baseline_x <- vals$Count[match("x", vals$Value_label)]
     expect_true(is.finite(baseline_x))
     expect_gt(baseline_x, 0)
-    
+
     # Exclude "x" in Step 2
     i_x <- which(vals$Value_label == "x")
     add_filters_exclude(rows = i_x)
     session$flushReact()
     expect_gt(nrow(shiny::isolate(tadat$selected_filters)), 0)
-    
+
     # Ensure removals applied (observer ran) before reading pie source
     ok <- wait_until(
       expr = function() any(startsWith(colnames(tadat$removals), paste0(prefix, "Exclude FieldA"))),
       session = session
     )
     expect_true(ok)
-    
+
     # Expected pie count for "x" based on current removals (including own-field)
     keep_all <- keep_mask_for(NULL)
     expected_x_after <- sum(labelize(tadat$raw$FieldA)[keep_all] == "x", na.rm = TRUE)
-    
+
     # Pie source reflects applied removals
     pie_src <- shiny::isolate(pie_source())
     sum_x <- sum(pie_src$FieldA == "x", na.rm = TRUE)

--- a/tests/testthat/test-mod_filter.R
+++ b/tests/testthat/test-mod_filter.R
@@ -1,8 +1,3 @@
-# tests/testthat/test-mod_filtering.R
-
-library(testthat)
-library(shiny)
-
 # Helpers
 new_tadat <- function(raw_df) {
   rv <- reactiveValues()
@@ -47,7 +42,7 @@ test_that("'Remove All Filters' clears per-field removals and restores Step 2 va
     values$selected_field <- "FieldA"
     session$flushReact()
     
-    vals0 <- isolate(filter_values())
+    vals0 <- shiny::isolate(filter_values())
     expect_true("x" %in% vals0$Value_label)
     baseline_x <- vals0$Count[match("x", vals0$Value_label)]
     expect_true(is.finite(baseline_x))
@@ -58,7 +53,7 @@ test_that("'Remove All Filters' clears per-field removals and restores Step 2 va
     session$flushReact()
     
     # Ensure helper updated state
-    expect_gt(nrow(isolate(tadat$selected_filters)), 0)
+    expect_gt(nrow(shiny::isolate(tadat$selected_filters)), 0)
     
     ok <- wait_until(
       expr = function() any(grepl(paste0("^", prefix, "Exclude FieldA is "), colnames(tadat$removals))),
@@ -66,10 +61,10 @@ test_that("'Remove All Filters' clears per-field removals and restores Step 2 va
     )
     expect_true(ok)
     
-    colname_before <- grep(paste0("^", prefix, "Exclude FieldA is "), colnames(isolate(tadat$removals)), value = TRUE)
+    colname_before <- grep(paste0("^", prefix, "Exclude FieldA is "), colnames(shiny::isolate(tadat$removals)), value = TRUE)
     expect_length(colname_before, 1)
     
-    vals1 <- isolate(filter_values())
+    vals1 <- shiny::isolate(filter_values())
     if ("x" %in% vals1$Value_label) {
       expect_equal(vals1$Count[match("x", vals1$Value_label)], 0)
     } else {
@@ -85,11 +80,11 @@ test_that("'Remove All Filters' clears per-field removals and restores Step 2 va
     )
     expect_true(ok2)
     
-    vals2 <- isolate(filter_values())
+    vals2 <- shiny::isolate(filter_values())
     expect_true("x" %in% vals2$Value_label)
     expect_equal(vals2$Count[match("x", vals2$Value_label)], baseline_x)
     
-    expect_equal(nrow(isolate(tadat$selected_filters)), 0)
+    expect_equal(nrow(shiny::isolate(tadat$selected_filters)), 0)
   })
 })
 
@@ -106,13 +101,13 @@ test_that("Exclude and Include Only update selected_filters and per-field remova
     values$selected_field <- "FieldA"
     session$flushReact()
     
-    vals <- isolate(filter_values())
+    vals <- shiny::isolate(filter_values())
     i_x  <- which(vals$Value_label == "x")
     i_na <- which(vals$Value_label == "NA - Not Available")
     
     add_filters_exclude(rows = i_x)
     session$flushReact()
-    expect_gt(nrow(isolate(tadat$selected_filters)), 0)
+    expect_gt(nrow(shiny::isolate(tadat$selected_filters)), 0)
     
     ok <- wait_until(
       expr = function() any(grepl(paste0("^", prefix, "Exclude FieldA is "), colnames(tadat$removals))),
@@ -120,18 +115,18 @@ test_that("Exclude and Include Only update selected_filters and per-field remova
     )
     expect_true(ok)
     
-    sf1 <- isolate(tadat$selected_filters)
+    sf1 <- shiny::isolate(tadat$selected_filters)
     expect_true(nrow(sf1) >= 1)
     expect_true(all(sf1$Filter == "Exclude"))
     expect_true("x" %in% sf1$Value)
     
-    colname <- grep(paste0("^", prefix, "Exclude FieldA is "), colnames(isolate(tadat$removals)), value = TRUE)
+    colname <- grep(paste0("^", prefix, "Exclude FieldA is "), colnames(shiny::isolate(tadat$removals)), value = TRUE)
     expect_length(colname, 1)
-    expect_true(any(isolate(tadat$removals[[colname]]), na.rm = TRUE))
+    expect_true(any(shiny::isolate(tadat$removals[[colname]]), na.rm = TRUE))
     
     add_filters_include_only(rows = i_na)
     session$flushReact()
-    expect_gt(nrow(isolate(tadat$selected_filters)), 0)
+    expect_gt(nrow(shiny::isolate(tadat$selected_filters)), 0)
     
     ok2 <- wait_until(
       expr = function() nrow(tadat$selected_filters) > 0 &&
@@ -141,7 +136,7 @@ test_that("Exclude and Include Only update selected_filters and per-field remova
     )
     expect_true(ok2)
     
-    sf2 <- isolate(tadat$selected_filters)
+    sf2 <- shiny::isolate(tadat$selected_filters)
     expect_false("NA - Not Available" %in% sf2$Value)
     
     ok3 <- wait_until(
@@ -151,7 +146,7 @@ test_that("Exclude and Include Only update selected_filters and per-field remova
     )
     expect_true(ok3)
     
-    reasons <- isolate(tadat$raw$TADA.RemovalReason)
+    reasons <- shiny::isolate(tadat$raw$TADA.RemovalReason)
     expect_true(any(is.na(reasons)))
     expect_true(any(!is.na(reasons)))
   })
@@ -169,7 +164,7 @@ test_that("Labelization aggregates NA-like values and pie source ignores own-fie
     values$selected_field <- "FieldA"
     session$flushReact()
     
-    vals <- isolate(filter_values())
+    vals <- shiny::isolate(filter_values())
     expect_true("NA - Not Available" %in% vals$Value_label)
     na_count <- vals$Count[match("NA - Not Available", vals$Value_label)]
     expect_gte(na_count, 3)
@@ -177,9 +172,9 @@ test_that("Labelization aggregates NA-like values and pie source ignores own-fie
     i_x <- which(vals$Value_label == "x")
     add_filters_exclude(rows = i_x)
     session$flushReact()
-    expect_gt(nrow(isolate(tadat$selected_filters)), 0)
+    expect_gt(nrow(shiny::isolate(tadat$selected_filters)), 0)
     
-    pie_src <- isolate(pie_source())
+    pie_src <- shiny::isolate(pie_source())
     expect_true(any(pie_src$FieldA == "x"))
   })
 })

--- a/tests/testthat/test-mod_filter.R
+++ b/tests/testthat/test-mod_filter.R
@@ -31,8 +31,6 @@ wait_until <- function(expr, session, timeout_ms = 6000, step_ms = 25) {
 
 test_that("'Remove All Filters' clears per-field removals and restores Step 2 values", {
   skip_on_cran()
-  rds_path <- system.file("extdata", "filter_descriptions.rds", package = "TADAShiny")
-  skip_if_not(file.exists(rds_path), "filter_descriptions.rds not found")
   
   d <- tiny_data()
   tadat <- new_tadat(d)
@@ -52,17 +50,17 @@ test_that("'Remove All Filters' clears per-field removals and restores Step 2 va
     add_filters_exclude(rows = i_x)
     session$flushReact()
     
-    # Ensure helper updated state
     expect_gt(nrow(shiny::isolate(tadat$selected_filters)), 0)
     
     ok <- wait_until(
-      expr = function() any(grepl(paste0("^", prefix, "Exclude FieldA is "), colnames(tadat$removals))),
+      expr = function() any(startsWith(colnames(tadat$removals), paste0(prefix, "Exclude FieldA"))),
       session = session
     )
     expect_true(ok)
     
-    colname_before <- grep(paste0("^", prefix, "Exclude FieldA is "), colnames(shiny::isolate(tadat$removals)), value = TRUE)
-    expect_length(colname_before, 1)
+    cn <- colnames(shiny::isolate(tadat$removals))
+    colname_before <- cn[startsWith(cn, paste0(prefix, "Exclude FieldA"))]
+    expect_gte(length(colname_before), 1)
     
     vals1 <- shiny::isolate(filter_values())
     if ("x" %in% vals1$Value_label) {
@@ -75,7 +73,7 @@ test_that("'Remove All Filters' clears per-field removals and restores Step 2 va
     session$flushReact()
     
     ok2 <- wait_until(
-      expr = function() !any(grepl(paste0("^", prefix, "Exclude FieldA is "), colnames(tadat$removals))),
+      expr = function() !any(startsWith(colnames(tadat$removals), paste0(prefix, "Exclude FieldA"))),
       session = session
     )
     expect_true(ok2)
@@ -85,13 +83,15 @@ test_that("'Remove All Filters' clears per-field removals and restores Step 2 va
     expect_equal(vals2$Count[match("x", vals2$Value_label)], baseline_x)
     
     expect_equal(nrow(shiny::isolate(tadat$selected_filters)), 0)
+    
+    reasons <- shiny::isolate(tadat$raw$TADA.RemovalReason)
+    expect_equal(length(reasons), nrow(tadat$raw))
+    expect_true(all(is.na(reasons)))
   })
 })
 
 test_that("Exclude and Include Only update selected_filters and per-field removals correctly", {
   skip_on_cran()
-  rds_path <- system.file("extdata", "filter_descriptions.rds", package = "TADAShiny")
-  skip_if_not(file.exists(rds_path), "filter_descriptions.rds not found")
   
   d <- tiny_data()
   tadat <- new_tadat(d)
@@ -110,7 +110,7 @@ test_that("Exclude and Include Only update selected_filters and per-field remova
     expect_gt(nrow(shiny::isolate(tadat$selected_filters)), 0)
     
     ok <- wait_until(
-      expr = function() any(grepl(paste0("^", prefix, "Exclude FieldA is "), colnames(tadat$removals))),
+      expr = function() any(startsWith(colnames(tadat$removals), paste0(prefix, "Exclude FieldA"))),
       session = session
     )
     expect_true(ok)
@@ -120,9 +120,10 @@ test_that("Exclude and Include Only update selected_filters and per-field remova
     expect_true(all(sf1$Filter == "Exclude"))
     expect_true("x" %in% sf1$Value)
     
-    colname <- grep(paste0("^", prefix, "Exclude FieldA is "), colnames(shiny::isolate(tadat$removals)), value = TRUE)
-    expect_length(colname, 1)
-    expect_true(any(shiny::isolate(tadat$removals[[colname]]), na.rm = TRUE))
+    cn <- colnames(shiny::isolate(tadat$removals))
+    colname <- cn[startsWith(cn, paste0(prefix, "Exclude FieldA"))]
+    expect_gte(length(colname), 1)
+    expect_true(any(shiny::isolate(tadat$removals[[colname[1]]]), na.rm = TRUE))
     
     add_filters_include_only(rows = i_na)
     session$flushReact()
@@ -152,29 +153,48 @@ test_that("Exclude and Include Only update selected_filters and per-field remova
   })
 })
 
-test_that("Labelization aggregates NA-like values and pie source ignores own-field removals", {
+test_that("Labelization aggregates NA-like values and pie source reflects applied removals", {
   skip_on_cran()
-  rds_path <- system.file("extdata", "filter_descriptions.rds", package = "TADAShiny")
-  skip_if_not(file.exists(rds_path), "filter_descriptions.rds not found")
   
   d <- tiny_data()
   tadat <- new_tadat(d)
+  prefix <- "Filter (module): "
   
   testServer(mod_filtering_server, args = list(tadat = tadat), {
     values$selected_field <- "FieldA"
     session$flushReact()
     
+    # Baseline: labelization aggregates NA-like values
     vals <- shiny::isolate(filter_values())
     expect_true("NA - Not Available" %in% vals$Value_label)
     na_count <- vals$Count[match("NA - Not Available", vals$Value_label)]
     expect_gte(na_count, 3)
     
+    # Baseline count for "x" from active data (honors TADA.Remove)
+    baseline_x <- vals$Count[match("x", vals$Value_label)]
+    expect_true(is.finite(baseline_x))
+    expect_gt(baseline_x, 0)
+    
+    # Exclude "x" in Step 2
     i_x <- which(vals$Value_label == "x")
     add_filters_exclude(rows = i_x)
     session$flushReact()
     expect_gt(nrow(shiny::isolate(tadat$selected_filters)), 0)
     
+    # Ensure removals applied (observer ran) before reading pie source
+    ok <- wait_until(
+      expr = function() any(startsWith(colnames(tadat$removals), paste0(prefix, "Exclude FieldA"))),
+      session = session
+    )
+    expect_true(ok)
+    
+    # Expected pie count for "x" based on current removals (including own-field)
+    keep_all <- keep_mask_for(NULL)
+    expected_x_after <- sum(labelize(tadat$raw$FieldA)[keep_all] == "x", na.rm = TRUE)
+    
+    # Pie source reflects applied removals
     pie_src <- shiny::isolate(pie_source())
-    expect_true(any(pie_src$FieldA == "x"))
+    sum_x <- sum(pie_src$FieldA == "x", na.rm = TRUE)
+    expect_equal(as.integer(sum_x), as.integer(expected_x_after))
   })
 })


### PR DESCRIPTION
Got the UI working correctly to add and remove filters.  This is issue #273. 
I am creating a separate ticket to address a related issue that still exists - the column TADA.RemovalReason is not being correctly updated and shows Filter values that have been removed in the UI.