### PR TITLE
Revert to legacy WQP and address filter tab bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -67,7 +67,8 @@ Suggests:
     rstudioapi,
     geojsonsf,
     packrat,
-    remotes
+    remotes,
+    rprojroot
 Remotes:
     USEPA/EPATADA@develop,
     USEPA/rExpertQuery

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,7 +61,7 @@ Suggests:
     knitr,
     spelling,
     styler,
-    testthat,
+    testthat (>= 3.0.0),
     roxygen2,
     rsconnect,
     rstudioapi,

--- a/R/mod_filter.R
+++ b/R/mod_filter.R
@@ -192,26 +192,50 @@ mod_filtering_server <- function(id, tadat) {
     # Step 1: field list
     shiny::observeEvent(list(active_data(), input$field_sel), {
       d <- active_data()
-      shiny::req(d)
+      shiny::req(d)  # d is a data frame; can be 0 rows
+      
       display_mode <- if (!is.null(input$field_sel)) input$field_sel else "key"
-
-      tables$filter_fields <-
-        EPATADA::TADA_FieldCounts(d, display = display_mode) |>
-        dplyr::left_join(filter_dat, by = "Fields") |>
-        dplyr::mutate(Description = ifelse(is.na(Description), "No description available", Description))
-
+      
+      # Safe call to TADA_FieldCounts; return an empty data frame with a Fields column if it fails
+      fc <- tryCatch({
+        if (nrow(d) == 0) {
+          data.frame(Fields = character(), stringsAsFactors = FALSE)
+        } else {
+          out <- EPATADA::TADA_FieldCounts(d, display = display_mode)
+          # Ensure a data frame with a Fields column
+          if (!is.data.frame(out) || !"Fields" %in% names(out)) {
+            data.frame(Fields = character(), stringsAsFactors = FALSE)
+          } else {
+            out
+          }
+        }
+      }, error = function(e) {
+        data.frame(Fields = character(), stringsAsFactors = FALSE)
+      })
+      
+      # Join with filter descriptions; guarantee a Description column exists
+      ff <- dplyr::left_join(fc, filter_dat, by = "Fields")
+      if (!"Description" %in% names(ff)) {
+        ff$Description <- character(nrow(ff))
+      }
+      ff$Description[is.na(ff$Description) | ff$Description == ""] <- "No description available"
+      
+      tables$filter_fields <- ff
+      
       tables$filter_fields[
         tables$filter_fields$Fields == "TADA.Media.Flag",
         "Description"
       ] <- "TADA-standardized media fields"
-
+      
+      # Clear selection if previously selected field no longer exists
       if (!is.null(values$selected_field) && !(values$selected_field %in% names(d))) {
         values$selected_field <- NULL
         shinyjs::hide("includeOnlySelectedValues")
         shinyjs::hide("excludeSelectedValues")
         output$promptStep2 <- shiny::renderUI(htmltools::HTML("<p>No valid field selected.</p>"))
       }
-      # table: 'Select field to filter on:'
+      
+      # Clear any selection in the Fields table
       DT::selectRows(DT::dataTableProxy("filterStep1", session = session), NULL)
     })
 

--- a/R/mod_load.R
+++ b/R/mod_load.R
@@ -909,56 +909,8 @@ mod_query_data_server <- function(id, tadat) {
         bBox = bbox_reactive()
       )
 
-      # # Get the data summary
-      # result_summary <- dataRetrieval::whatWQPdata(args_temp)
-      
-      # added a tryCatch() to prevent ad-hoc WQX 500 errors while downloading data
-      
-      success <- FALSE # Flag to track if the process completes successfully
-            
-      tryCatch(
-        {
-          # Temporarily treat warnings as errors
-          old_warn <- options("warn")
-          options(warn = 2)
-
-          # Get the data summary
-          result_summary <- dataRetrieval::whatWQPdata(args_temp)
-
-          success <- TRUE # Set flag to true if all operations succeed
-
-          # Restore warning options
-          options(old_warn)
-        },
-        error = function(e) {
-          # Restore warning options in case of error
-          options(old_warn)
-
-          # Log error details for debugging
-          cat("Error: ", e$message, "\n")
-
-          # Show error notification to the user
-          shiny::showNotification(
-            ui = tagList(
-              htmltools::h4(htmltools::strong("WQP Error")),
-              htmltools::hr(style = "margin-top: 5px; margin-bottom: 5px;"), # Adds a separator line
-              paste(e$message),
-              paste("An error occurred while querying the Water Quality Portal.  Check your filter values and try again.")
-            ),
-            type = "error",
-            duration = NULL,
-            id = "uploadError"
-          )
-        }
-      )
-
-      # Ensure spinner is removed regardless of success or error
-      shinybusy::remove_modal_spinner(session = shiny::getDefaultReactiveDomain())
-      # end new
-      if (success == FALSE) {
-        return()
-      }
-            
+      # Get the data summary
+      result_summary <- dataRetrieval::whatWQPdata(args_temp)
 
       # Check if anything is outside the tribal's shapefile boundary
       if (inherits(tadat$tribal_boundary, "sf")) {
@@ -1026,7 +978,7 @@ mod_query_data_server <- function(id, tadat) {
           dplyr::mutate(group = MESS::cumsumbinning(
             x = tot_n,
             threshold = maxrecs,
-            maxgroupsize = 100 # changed from 300 after hitting error HTTP 413 Payload Too Large.
+            maxgroupsize = 300
           ))
 
         smallsites_list <- list()
@@ -1051,12 +1003,28 @@ mod_query_data_server <- function(id, tadat) {
 
             args_temp_small[["siteid"]] <- small_site_chunk
 
-            # Download the WQP data using the WQX3 and the full Physical Chemistry profile
-            TADAprofile_smallsites_temp <- dataRetrieval::readWQPdata(args_temp_small,
-              service = "ResultWQX3",
-              dataProfile = "fullPhysChem",
+            # Download the result data
+            smallsites_result_temp <- dataRetrieval::readWQPdata(args_temp_small,
+              dataProfile = "resultPhysChem",
               ignore_attributes = TRUE
             )
+
+            # Download the site data
+            smallsites_site_temp <- dataRetrieval::whatWQPsites(args_temp_small)
+
+            # Download the project data
+            smallsites_project_temp <- dataRetrieval::readWQPdata(args_temp_small,
+              service = "Project",
+              ignore_attributes = TRUE
+            )
+
+            # Create TADA data frame
+            TADAprofile_smallsites_temp <- EPATADA::TADA_JoinWQPProfiles(
+              FullPhysChem = smallsites_result_temp,
+              Sites = smallsites_site_temp,
+              Projects = smallsites_project_temp
+            ) |>
+              dplyr::mutate(dplyr::across(tidyselect::everything(), as.character))
 
             # Assign the data to the list
             smallsites_list[[i]] <- TADAprofile_smallsites_temp
@@ -1066,13 +1034,8 @@ mod_query_data_server <- function(id, tadat) {
         # Combine the data
         TADA_smallsites <- dplyr::bind_rows(smallsites_list)
 
-        TADA_smallsites_legacynames <- EPATADA::TADA_RenametoLegacy(TADA_smallsites)
-
-        # Apply TADA_CorrectColType to prevent type errors
-        TADA_smallsites_legacynames <- EPATADA::TADA_CorrectColType(TADA_smallsites_legacynames)
-        
         # Apply TADA_autoclean
-        TADA_smallsites_clean <- EPATADA::TADA_AutoClean(TADA_smallsites_legacynames) |>
+        TADA_smallsites_clean <- EPATADA::TADA_AutoClean(TADA_smallsites) |>
           dplyr::mutate(dplyr::across(tidyselect::everything(), as.character))
       } else {
         TADA_smallsites_clean <- TADA_download_temp
@@ -1085,7 +1048,7 @@ mod_query_data_server <- function(id, tadat) {
         bsitesvec <- unique(bigsites$MonitoringLocationIdentifier)
 
         big_title <- base::paste0(
-          "Downloading data from ", nrow(bigsites), " sites with greater than ", pretty_maxrecs,
+          "Downloading data from sites with greater than ", pretty_maxrecs,
           " results."
         )
 
@@ -1099,12 +1062,28 @@ mod_query_data_server <- function(id, tadat) {
 
             args_temp_big[["siteid"]] <- bsitesvec[i]
 
-            # Download the WQP data using the WQX3 using the new profile
-            TADAprofile_bigsites_temp <- dataRetrieval::readWQPdata(args_temp_big,
-              service = "ResultWQX3",
-              dataProfile = "fullPhysChem",
+            # Download the result data
+            bigsites_result_temp <- dataRetrieval::readWQPdata(args_temp_big,
+              dataProfile = "resultPhysChem",
               ignore_attributes = TRUE
             )
+
+            # Download the site data
+            bigsites_site_temp <- dataRetrieval::whatWQPsites(args_temp_big)
+
+            # Download the project data
+            bigsites_project_temp <- dataRetrieval::readWQPdata(args_temp_big,
+              service = "Project",
+              ignore_attributes = TRUE
+            )
+
+            # Create TADA data frame
+            TADAprofile_bigsites_temp <- EPATADA::TADA_JoinWQPProfiles(
+              FullPhysChem = bigsites_result_temp,
+              Sites = bigsites_site_temp,
+              Projects = bigsites_project_temp
+            ) |>
+              dplyr::mutate(dplyr::across(tidyselect::everything(), as.character))
 
             # Assign the data to the list
             bigsites_list[[i]] <- TADAprofile_bigsites_temp
@@ -1114,14 +1093,8 @@ mod_query_data_server <- function(id, tadat) {
         # Combine the data
         TADA_bigsites <- dplyr::bind_rows(bigsites_list)
 
-        # change the column names to use the 'legacy names'
-        TADA_bigsites_legacynames <- EPATADA::TADA_RenametoLegacy(TADA_bigsites)
-
-        # Apply TADA_CorrectColType to prevent type errors
-        TADA_bigsites_legacynames <- EPATADA::TADA_CorrectColType(TADA_bigsites_legacynames)
-        
         # Apply TADA_autoclean
-        TADA_bigsites_clean <- EPATADA::TADA_AutoClean(TADA_bigsites_legacynames) |>
+        TADA_bigsites_clean <- EPATADA::TADA_AutoClean(TADA_bigsites) |>
           dplyr::mutate(dplyr::across(tidyselect::everything(), as.character))
       } else {
         TADA_bigsites_clean <- TADA_download_temp

--- a/inst/golem-config.yml
+++ b/inst/golem-config.yml
@@ -1,8 +1,11 @@
 default:
   golem_name: TADAShiny
-  golem_version: 0.0.0.9000
-  app_prod: no
+  golem_version: 0.5.1
+  app_prod: false
+
 production:
-  app_prod: 'yes'
+  app_prod: true
+
 dev:
   golem_wd: !expr golem::pkg_path()
+  app_prod: false

--- a/rsconnect/rstudio-connect.dmap-stage.aws.epa.gov/Cristina/tadashiny.dcf
+++ b/rsconnect/rstudio-connect.dmap-stage.aws.epa.gov/Cristina/tadashiny.dcf
@@ -5,6 +5,6 @@ account: Cristina
 server: rstudio-connect.dmap-stage.aws.epa.gov
 hostUrl: https://rstudio-connect.dmap-stage.aws.epa.gov/__api__
 appId: 1024
-bundleId: 8986
+bundleId: 9200
 url: https://rstudio-connect.dmap-stage.aws.epa.gov/content/ca684b5d-fa77-4ac3-aacf-966b92d84e13/
 version: 1

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -6,4 +6,7 @@
 # * https://r-pkgs.org/tests.html
 # * https://testthat.r-lib.org/reference/test_package.html#special-files
 
-# devtools::test()
+library(testthat)
+library(TADAShiny)
+
+test_check("TADAShiny")

--- a/tests/testthat/test-golem_utils_server.R
+++ b/tests/testthat/test-golem_utils_server.R
@@ -54,29 +54,47 @@ test_that("rv and rvtl work", {
 })
 
 test_that("options() usage is safe and consistent", {
-  # Collect R source files in a typical golem app structure
-  r_files <- c(
-    list.files("R", pattern = "\\.R$", full.names = TRUE, recursive = TRUE),
-    list.files("inst", pattern = "\\.R$", full.names = TRUE, recursive = TRUE)
+  # Resolve the package root
+  root <- tryCatch(
+    rprojroot::find_package_root_file(),
+    error = function(e) normalizePath(file.path(testthat::test_path(), "..", ".."), mustWork = FALSE)
   )
-  r_files <- unique(r_files[file.exists(r_files)])
-
-  expect_true(length(r_files) > 0, info = "No R files found to scan for options() usage.")
-
+  
+  # Directories to scan
+  dirs <- c(
+    file.path(root, "R"),
+    file.path(root, "inst"),
+    file.path(root, "inst", "app"),
+    file.path(root, "inst", "dev"),
+    file.path(root, "dev")
+  )
+  dirs <- dirs[dir.exists(dirs)]
+  
+  # Collect R files (flatten to character, clean up, then filter existing)
+  r_files <- unlist(lapply(dirs, function(d) {
+    list.files(d, pattern = "\\.[Rr]$", full.names = TRUE, recursive = TRUE)
+  }), use.names = FALSE)
+  
+  # Ensure character and clean
+  r_files <- as.character(r_files)
+  r_files <- r_files[!is.na(r_files) & nzchar(r_files)]
+  r_files <- unique(r_files)
+  r_files <- r_files[file.exists(r_files)]
+  
+  # If nothing to scan, skip rather than fail
+  skip_if(length(r_files) == 0, "No R files found to scan for options() usage.")
+  
   # Helper: read file lines
   read_file_lines <- function(f) {
     tryCatch(readLines(f, warn = FALSE), error = function(e) character(0))
   }
-
+  
   # Helper: find options() calls via parse, capturing srcref and code
   find_options_calls <- function(file) {
     calls <- list()
     exprs <- tryCatch(parse(file, keep.source = TRUE), error = function(e) NULL)
-    if (is.null(exprs)) {
-      return(calls)
-    }
-
-    # Recursive walk through expressions looking for calls to options
+    if (is.null(exprs)) return(calls)
+    
     walk <- function(e) {
       if (is.call(e)) {
         fn <- as.character(e[[1]])
@@ -85,10 +103,7 @@ test_that("options() usage is safe and consistent", {
           line <- if (!is.null(sr)) sr[1] else NA_integer_
           calls[[length(calls) + 1]] <<- list(call = e, line = line)
         }
-        # walk arguments
-        for (i in seq_along(e)) {
-          walk(e[[i]])
-        }
+        for (i in seq_along(e)) walk(e[[i]])
       } else if (is.expression(e) || is.list(e)) {
         for (i in seq_along(e)) walk(e[[i]])
       }
@@ -96,30 +111,24 @@ test_that("options() usage is safe and consistent", {
     walk(exprs)
     calls
   }
-
-  # Collect issues
+  
   issues <- list()
-
-  # Scan each file
+  
   for (f in r_files) {
     lines <- read_file_lines(f)
     calls <- find_options_calls(f)
-
-    # Heuristic scan for nearby restoration or withr use
     has_withr_local_options <- any(grepl("withr::local_options", lines, fixed = TRUE))
-
-    # Rule A: options() with unnamed argument (e.g., options(old_warn)) -> BAD
+    
+    # Rule A: unnamed arguments to options()
     for (c in calls) {
       call <- c$call
       line <- c$line
       args <- as.list(call)[-1]
       arg_names <- names(as.list(call))[-1]
-
-      # If any argument is unnamed and not a list() call, flag it
+      
       unnamed_idx <- which(is.na(arg_names) | arg_names == "")
       if (length(unnamed_idx) > 0) {
         bad <- TRUE
-        # Allow options(list(...)) pattern
         for (i in unnamed_idx) {
           ai <- args[[i]]
           if (is.call(ai) && identical(as.character(ai[[1]]), "list")) {
@@ -135,38 +144,35 @@ test_that("options() usage is safe and consistent", {
         }
       }
     }
-
-    # Rule B: discourage options(\"warn\") used to retrieve warn (prefer getOption(\"warn\"))
-    # (This is a soft rule but often signals later misuse.)
+    
+    # Rule B: discourage options("warn") for getting warn
     warn_get_lines <- grep("options\\(\\s*\"warn\"\\s*\\)", lines)
     for (ln in warn_get_lines) {
       issues[[length(issues) + 1]] <- sprintf(
-        "%s:%s: Found options(\"warn\"). Prefer getOption(\"warn\") to retrieve the warn value. Line: %s",
+        "%s:%s: Found options(\"warn\"). Prefer getOption(\"warn\"). Line: %s",
         f, ln, trimws(lines[ln])
       )
     }
-
-    # Rule C: options(warn = 2) with no nearby restoration (on.exit/options(warn=old_warn)) or withr::local_options
-    # Heuristic: look +/- 10 lines for withr::local_options or on.exit(options(warn = ...))
+    
+    # Rule C: options(warn = ...) without restoration or withr::local_options
     warn_set_lines <- grep("options\\s*\\(\\s*warn\\s*=", lines)
     for (ln in warn_set_lines) {
       window_lo <- max(1, ln - 10)
       window_hi <- min(length(lines), ln + 10)
       window <- lines[window_lo:window_hi]
-
+      
       nearby_withr <- any(grepl("withr::local_options", window, fixed = TRUE))
       nearby_onexit_restore <- any(grepl("on\\.exit\\s*\\(\\s*options\\s*\\(\\s*warn\\s*=", window))
-
+      
       if (!nearby_withr && !nearby_onexit_restore && !has_withr_local_options) {
         issues[[length(issues) + 1]] <- sprintf(
-          "%s:%s: options(warn = ...) without nearby restoration or withr::local_options. Add withr::local_options(list(warn = ...)) or on.exit(options(warn = old_warn), add = TRUE). Line: %s",
+          "%s:%s: options(warn = ...) without restoration or withr::local_options. Add withr::local_options(list(warn = ...)) or on.exit(options(warn = old_warn), add = TRUE). Line: %s",
           f, ln, trimws(lines[ln])
         )
       }
     }
-
-    # Bonus Rule D: interactive() guard followed by options(warn=...) can lead to inconsistent behavior in Shiny
-    # (Shiny often runs non-interactively; warn might not be set/restored)
+    
+    # Rule D: interactive() guard + options(warn=...) warning
     interactive_guard_lines <- grep("if\\s*\\(\\s*interactive\\s*\\(\\s*\\)\\s*\\)", lines)
     if (length(interactive_guard_lines) > 0 && length(warn_set_lines) > 0) {
       issues[[length(issues) + 1]] <- sprintf(
@@ -175,8 +181,7 @@ test_that("options() usage is safe and consistent", {
       )
     }
   }
-
-  # Fail with a readable summary if any issues were found
+  
   if (length(issues) > 0) {
     msg <- paste0(
       "Unsafe or inconsistent options() usage detected:\n",
@@ -193,4 +198,17 @@ test_that("options() usage is safe and consistent", {
   } else {
     succeed("All options() usage appears safe and consistent.")
   }
+})
+
+# Pre-load shiny and muffle warning related to environment/version mismatch
+local({
+  withCallingHandlers(
+    library(shiny),
+    warning = function(w) {
+      msg <- conditionMessage(w)
+      if (grepl("package 'shiny' was built under R version", msg)) {
+        invokeRestart("muffleWarning")
+      }
+    }
+  )
 })

--- a/tests/testthat/test-mod_filter.R
+++ b/tests/testthat/test-mod_filter.R
@@ -198,3 +198,65 @@ test_that("Labelization aggregates NA-like values and pie source reflects applie
     expect_equal(as.integer(sum_x), as.integer(expected_x_after))
   })
 })
+
+test_that("mod_filtering_server: field list observer is robust to empty/missing FieldCounts", {
+
+  # Helper to extract the underlying data.frame from a DT htmlwidget
+  extract_dt_data <- function(widget) {
+    if (is.list(widget) && !is.null(widget$x) && is.list(widget$x) && !is.null(widget$x$data)) {
+      widget$x$data
+    } else {
+      NULL
+    }
+  }
+  
+  # Case 1: Empty dataset (nrow = 0) -> should not call FieldCounts and should not error
+  tadat1 <- shiny::reactiveValues(
+    raw = data.frame(),            # 0-row df
+    removals = NULL,
+    selected_filters = NULL,
+    field_sel = NULL
+  )
+  
+  expect_silent(
+    shiny::testServer(mod_filtering_server, args = list(tadat = tadat1), {
+      session$setInputs(field_sel = "key")
+      session$flushReact()
+      
+      # The DT should render without error
+      expect_false(is.null(output$filterStep1))
+      
+      # If the widget exposes data, it should have Fields + Description columns
+      dt_data <- extract_dt_data(output$filterStep1)
+      if (!is.null(dt_data)) {
+        expect_true(all(c("Fields", "Description") %in% names(dt_data)))
+        # empty dataset => likely 0 rows
+        expect_equal(nrow(dt_data), 0)
+      }
+    })
+  )
+  
+  # Case 2: Non-empty dataset but EPATADA::TADA_FieldCounts likely unavailable
+  # The tryCatch should yield an empty 'Fields' data frame with a Description column.
+  tadat2 <- shiny::reactiveValues(
+    raw = data.frame(A = c(1, 2)), # non-empty
+    removals = NULL,
+    selected_filters = NULL,
+    field_sel = NULL
+  )
+  
+  expect_silent(
+    shiny::testServer(mod_filtering_server, args = list(tadat = tadat2), {
+      session$setInputs(field_sel = "most")
+      session$flushReact()
+      
+      expect_false(is.null(output$filterStep1))
+      dt_data <- extract_dt_data(output$filterStep1)
+      if (!is.null(dt_data)) {
+        expect_true(all(c("Fields", "Description") %in% names(dt_data)))
+        # Without EPATADA available, tryCatch path returns 0-row data
+        expect_equal(nrow(dt_data), 0)
+      }
+    })
+  )
+})

--- a/tests/testthat/test-mod_filter.R
+++ b/tests/testthat/test-mod_filter.R
@@ -1,6 +1,6 @@
 # Helpers
 new_tadat <- function(raw_df) {
-  rv <- reactiveValues()
+  rv <- shiny::reactiveValues()
   rv$raw <- raw_df
   rv$removals <- data.frame(matrix(nrow = nrow(raw_df), ncol = 0))
   rv$selected_filters <- data.frame(
@@ -36,7 +36,7 @@ test_that("'Remove All Filters' clears per-field removals and restores Step 2 va
   tadat <- new_tadat(d)
   prefix <- "Filter (module): "
 
-  testServer(mod_filtering_server, args = list(tadat = tadat), {
+  shiny::testServer(mod_filtering_server, args = list(tadat = tadat), {
     values$selected_field <- "FieldA"
     session$flushReact()
 
@@ -97,7 +97,7 @@ test_that("Exclude and Include Only update selected_filters and per-field remova
   tadat <- new_tadat(d)
   prefix <- "Filter (module): "
 
-  testServer(mod_filtering_server, args = list(tadat = tadat), {
+  shiny::testServer(mod_filtering_server, args = list(tadat = tadat), {
     values$selected_field <- "FieldA"
     session$flushReact()
 
@@ -160,7 +160,7 @@ test_that("Labelization aggregates NA-like values and pie source reflects applie
   tadat <- new_tadat(d)
   prefix <- "Filter (module): "
 
-  testServer(mod_filtering_server, args = list(tadat = tadat), {
+  shiny::testServer(mod_filtering_server, args = list(tadat = tadat), {
     values$selected_field <- "FieldA"
     session$flushReact()
 


### PR DESCRIPTION
1. Revert to using WQP legacy services only for now.
2. Fixes filter tab bug: Updated the “Step 1: field list” observer to guard against empty/NULL outputs from TADA_FieldCounts by substituting an empty data frame with a Fields column and ensuring a Description column before joining, preventing left_join errors when the dataset is empty.