### PR TITLE
Bisese may13 - fix error with loading example data; and organize filters on load page to group WQX only options.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -74,3 +74,4 @@ URL: https://github.com/USEPA/TADAShiny
 BugReports: https://github.com/USEPA/TADAShiny/issues
 Roxygen: list(markdown = TRUE)
 Config/roxygen2/version: 8.0.0
+RoxygenNote: 7.3.3

--- a/R/mod_load.R
+++ b/R/mod_load.R
@@ -1051,9 +1051,9 @@ mod_query_data_server <- function(id, tadat) {
       if (input$example_data == "EPA Region 5 May 1-7 2019 (173k results)") {
         raw <- EPATADA::Data_R5_TADAPackageDemo
       }
-      if (input$example_data == "Six Tribal Nations (143k results)") {
-        raw <- EPATADA::Data_TribalNations
-      }
+      # if (input$example_data == "Six Tribal Nations (143k results)") {
+      #   raw <- EPATADA::Data_TribalNations
+      # }
       if (input$example_data == "Utah Nutrients (15k results)") {
         raw <- EPATADA::Data_Nutrients_UT
       }

--- a/R/mod_load.R
+++ b/R/mod_load.R
@@ -12,6 +12,7 @@ get_example_data_map <- function() {
     "EPA Region 5 May 1-7 2019 (173k results)" = function() EPATADA::Data_R5_TADAPackageDemo,
     "Six Tribal Nations (143k results)" = function() EPATADA::Data_TribalNations
   )
+  m
 }
 
 # Build map lazily so objects are only touched when selected
@@ -926,7 +927,7 @@ mod_query_data_server <- function(id, tadat) {
     ## greys out Load button for example data until file has been selected
     # https://stackoverflow.com/questions/24175997/force-no-default-selection-in-selectinput
     shiny::observeEvent(input$example_data, {
-      if (!is.na(input$example_data) && nchar(input$example_data) > 1) {
+      if (!is.na(input$example_data) && !is.na(input$example_data) > 1) {
         shinyjs::enable("example_data_go")
       }
     })
@@ -1129,7 +1130,7 @@ mod_query_data_server <- function(id, tadat) {
         return(chars)
       } else {
         match_type <- "contains"
-        if (input$match_type_selector != "") {
+        if (isTRUE(nzchar(input$match_type_selector))) {
           match_type <- input$match_type_selector
         }
         # set the grep pattern for each match type

--- a/R/mod_load.R
+++ b/R/mod_load.R
@@ -262,7 +262,7 @@ mod_query_data_ui <- function(id) {
             shiny::tags$i(
               class = "glyphicon glyphicon-info-sign",
               style = "color:#0072B2;",
-              title = "TADA is designed to work with water data"
+              title = "TADA is designed to work primarily with 'Water' data"
             )
           ),
           choices = c("", media),
@@ -347,12 +347,12 @@ mod_query_data_ui <- function(id) {
         shiny::selectizeInput(
           ns("org"),
           shiny::tags$span(
-            "Organization(s)",
-            shiny::tags$i(
-              class = "glyphicon glyphicon-info-sign",
-              style = "color:#0072B2;",
-              title = "Organization filter is only available with the Data Source EPA (WQX)"
-            )
+            "Organization(s)" # ,
+            # shiny::tags$i(
+            #   class = "glyphicon glyphicon-info-sign",
+            #   style = "color:#0072B2;",
+            #   title = "Organization filter is only available with the Data Source EPA (WQX)"
+            # )
           ),
           choices = NULL,
           options = list(placeholder = "Start typing or use drop down menu"),
@@ -372,7 +372,7 @@ mod_query_data_ui <- function(id) {
 
     ),
     shiny::fluidRow(
-      column(10,
+      column(5,
            shiny::fluidRow( # this is what allows both widgets to be side-by-side
           htmltools::h3("Tribal Data", style = "margin-bottom: 10px; font-size: 16px;"),
           htmltools::hr(style = "margin-bottom: 0px; margin-top: 0px;"),
@@ -390,6 +390,7 @@ mod_query_data_ui <- function(id) {
       )
     ),
     shiny::fluidRow(
+      htmltools::br(),
       column(
         4,
         shiny::radioButtons(ns("providers"),
@@ -1277,9 +1278,11 @@ mod_query_data_server <- function(id, tadat) {
         # display a modal and return because these are not compatible
         # browser()
         shiny::showModal(shiny::modalDialog(title = "Input warning",
-          paste0("The Data Source USGS (Samples Data API) does not recognize the Country/Ocean(s), Organization(s), Project(s), ",
-          "or Tribal Data arguments.",
-         " Use those 5 filters only with the EPA (WQX) data source."), easyClose = TRUE))
+          shiny::HTML(paste0("The Data Source '<strong>USGS (Samples Data API)</strong>' is not compatible ",
+                             "with any of the EPA (WQX) Metadata Filters. Please either change your Data Source ",
+                             "selection to '<strong>EPA (WQX)</strong>' or remove any of the following filters: ",
+                             "Country/Ocean(s), Organization(s), Project(s), and Tribal Data.")), 
+         easyClose = TRUE))
         return(NULL)
       }
       
@@ -1743,7 +1746,7 @@ mod_query_data_server <- function(id, tadat) {
 
         shiny::showModal(shiny::modalDialog(
           title = "NWIS Error",
-          HTML(nwis_error_message_text),
+          shiny::HTML(nwis_error_message_text),
           easyClose = FALSE, # Set to FALSE to force user to use a button to close
           footer = tagList(
             shiny::modalButton("Dismiss")

--- a/R/mod_load.R
+++ b/R/mod_load.R
@@ -9,15 +9,9 @@
 get_example_data_map <- function() {
   m <- list(
     "Utah Nutrients (15k results)" = function() EPATADA::Data_Nutrients_UT,
-    "EPA Region 5 May 1-7 2019 (173k results)" = function() EPATADA::Data_R5_TADAPackageDemo
+    "EPA Region 5 May 1-7 2019 (173k results)" = function() EPATADA::Data_R5_TADAPackageDemo,
+    "Six Tribal Nations (143k results)" = function() EPATADA::Data_TribalNations
   )
-
-  # Optional dataset: add only if exported by EPATADA
-  if ("Data_TribalNations" %in% getNamespaceExports("EPATADA")) {
-    m[["Six Tribal Nations (143k results)"]] <- function() EPATADA::Data_TribalNations
-  }
-
-  m
 }
 
 # Build map lazily so objects are only touched when selected

--- a/R/mod_load.R
+++ b/R/mod_load.R
@@ -3,6 +3,26 @@
   nzchar(Sys.getenv("TADAS_OFFLINE", "")) # set TADAS_OFFLINE=true in CI to force offline
 }
 
+# source of Example UI options and then loaded data frames
+# for the example datasets.  These are used to populate the
+# example dataset dropdown and load the data when selected.
+get_example_data_map <- function() {
+  m <- list(
+    "Utah Nutrients (15k results)" = function() EPATADA::Data_Nutrients_UT,
+    "EPA Region 5 May 1-7 2019 (173k results)" = function() EPATADA::Data_R5_TADAPackageDemo
+  )
+
+  # Optional dataset: add only if exported by EPATADA
+  if ("Data_TribalNations" %in% getNamespaceExports("EPATADA")) {
+    m[["Six Tribal Nations (143k results)"]] <- function() EPATADA::Data_TribalNations
+  }
+
+  m
+}
+
+# Build map lazily so objects are only touched when selected
+example_data_map <- get_example_data_map()
+
 .safe_req_string <- function(u, timeout = 30, max_tries = 3) {
   if (.tadas_offline()) {
     return(NULL)
@@ -150,12 +170,7 @@ mod_query_data_ui <- function(id) {
       column(3, shiny::selectInput(
         ns("example_data"),
         "Use example data",
-        choices = c(
-          "",
-          "Nutrients Utah (15k results)",
-          "EPA Region 5 May 1-7 2019 (172k results)",
-          "Tribal (136k results)"
-        )
+        choices = c("", names(example_data_map))
       ))
     ),
     shiny::fluidRow(column(
@@ -201,29 +216,19 @@ mod_query_data_ui <- function(id) {
     "Choose at least one spatial location from the following options. If multiple options are used, the locations must be overlapping.",
     htmltools::br(),
     shiny::fluidRow(
-      column(4, shiny::selectizeInput(ns("countryocean"),
-        "Country/Ocean(s)",
-        choices = NULL,
-        multiple = TRUE
-      ))
-    ),
-    shiny::fluidRow(
       column(4, shiny::selectizeInput(ns("state"), "State", choices = NULL)),
       column(
         4,
         shiny::selectizeInput(ns("county"), "County (pick state first)", choices = NULL)
-      )
-    ),
-    shiny::fluidRow(
-      column(4, shiny::selectizeInput(ns("tribe_layer"), "Tribe Data Layers",
-        choices = NULL
-      )),
+      ),
       column(
         4,
-        shiny::selectizeInput(ns("tribe_name"), "Tribe Name (pick data layers first)",
-          choices = NULL
+        shiny::selectizeInput(ns("siteid"),
+          "Monitoring Location ID(s)",
+          choices = NULL,
+          multiple = TRUE
         )
-      )
+      )      
     ),
     shiny::fluidRow(
       column(
@@ -235,46 +240,9 @@ mod_query_data_ui <- function(id) {
       )
     ),
     htmltools::br(),
-    htmltools::br(),
-    shiny::fluidRow(
-      column(
-        4,
-        shiny::selectizeInput(ns("siteid"),
-          "Monitoring Location ID(s)",
-          choices = NULL,
-          multiple = TRUE
-        )
-      )
-    ),
     htmltools::h4("Metadata Filters"),
     shiny::fluidRow(
-      column(
-        3,
-        shiny::selectizeInput(
-          ns("org"),
-          shiny::tags$span(
-            "Organization(s)",
-            shiny::tags$i(
-              class = "glyphicon glyphicon-info-sign",
-              style = "color:#0072B2;",
-              title = "Organization filter is only available with the Data Source EPA (WQX)"
-            )
-          ),          
-          choices = NULL,
-          options = list(placeholder = "Start typing or use drop down menu"),
-          multiple = TRUE
-        )
-      ),
-      column(
-        5,
-        shiny::selectizeInput(
-          ns("project"),
-          "Project(s)",
-          choices = NULL,
-          options = list(placeholder = "Start typing or use drop down menu"),
-          multiple = TRUE
-        )
-      ),
+
       column(
         4,
         shiny::selectizeInput(
@@ -284,9 +252,7 @@ mod_query_data_ui <- function(id) {
           options = list(placeholder = "Start typing or use drop down menu"),
           multiple = TRUE
         )
-      )
-    ),
-    shiny::fluidRow(
+      ),
       column(
         3,
         shiny::selectizeInput(
@@ -303,7 +269,9 @@ mod_query_data_ui <- function(id) {
           selected = c("Water"), # "water" gets added automatically if Water is included.  This is for older USGS data
           multiple = TRUE
         )
-      ),
+      ),      
+    ),
+    shiny::fluidRow(
       column(
         5,
         shiny::fluidRow( # this is what allows both widgets to be side-by-side
@@ -354,6 +322,71 @@ mod_query_data_ui <- function(id) {
           options = list(placeholder = "Start typing or use drop down menu"),
           multiple = TRUE
         )
+      )
+    ),
+    shiny::fluidRow(
+      column(9,
+           htmltools::h4("EPA (WQX) Metadata Filters", style = "margin-top: 30px;"),
+           htmltools::HTML(
+           "<i>Note: These filters are only compatible with the EPA (WQX) data source option.
+           If you select any of these filters, the Data Source option USGS (Samples Data API) will not be available.</i>"
+           ),
+           htmltools::hr(style = "margin-bottom: 15px; margin-top: 0px;")
+      )
+    ),
+    shiny::fluidRow(
+
+      column(3, shiny::selectizeInput(ns("countryocean"),
+        "Country/Ocean(s)",
+        choices = NULL,
+        multiple = TRUE
+      )),
+
+      column(
+        3,
+        shiny::selectizeInput(
+          ns("org"),
+          shiny::tags$span(
+            "Organization(s)",
+            shiny::tags$i(
+              class = "glyphicon glyphicon-info-sign",
+              style = "color:#0072B2;",
+              title = "Organization filter is only available with the Data Source EPA (WQX)"
+            )
+          ),
+          choices = NULL,
+          options = list(placeholder = "Start typing or use drop down menu"),
+          multiple = TRUE
+        )
+      ),
+      column(
+        3,
+        shiny::selectizeInput(
+          ns("project"),
+          "Project(s)",
+          choices = NULL,
+          options = list(placeholder = "Start typing or use drop down menu"),
+          multiple = TRUE
+        )
+      ),
+
+    ),
+    shiny::fluidRow(
+      column(10,
+           shiny::fluidRow( # this is what allows both widgets to be side-by-side
+          htmltools::h3("Tribal Data", style = "margin-bottom: 10px; font-size: 16px;"),
+          htmltools::hr(style = "margin-bottom: 0px; margin-top: 0px;"),
+          column(4, style = "margin-left: -15px;", shiny::selectizeInput(ns("tribe_layer"), "Data Layers",
+            choices = NULL
+          )),
+          column(
+            6,
+            shiny::selectizeInput(ns("tribe_name"), "Tribe Name (pick data layers first)",
+              choices = NULL
+            )
+          )
+        )
+
       )
     ),
     shiny::fluidRow(
@@ -1046,17 +1079,10 @@ mod_query_data_server <- function(id, tadat) {
         session = shiny::getDefaultReactiveDomain()
       )
 
-      tadat$example_data <- input$example_data
-
-      if (input$example_data == "EPA Region 5 May 1-7 2019 (173k results)") {
-        raw <- EPATADA::Data_R5_TADAPackageDemo
-      }
-      # if (input$example_data == "Six Tribal Nations (143k results)") {
-      #   raw <- EPATADA::Data_TribalNations
-      # }
-      if (input$example_data == "Utah Nutrients (15k results)") {
-        raw <- EPATADA::Data_Nutrients_UT
-      }
+      # get the data from the example_data_map based on the user's selection.
+      # This is a named list of functions that each return a dataset, so we
+      # call the function corresponding to the user's selection to get the dataset.
+      raw <- example_data_map[[input$example_data]]()
 
       # Clean → order → restrict → initialize
       raw <- EPATADA::TADA_AutoClean(raw)
@@ -1178,7 +1204,7 @@ mod_query_data_server <- function(id, tadat) {
     shiny::updateSelectizeInput(
       session,
       "tribe_layer",
-      choices = names(tribal_list),
+      choices = c("", names(tribal_list)),
       selected = character(0),
       options = list(placeholder = "Select tribal data layer", maxItems = 1),
       server = TRUE
@@ -1243,12 +1269,17 @@ mod_query_data_server <- function(id, tadat) {
       } else {
         tadat$countrycode <- input$countryocean
       }
-      if((input$providers == "all" || input$providers == "NWIS") && !is.null(input$org)) {
+
+      if((input$providers == "all" || input$providers == "NWIS") &&
+         (shiny::isTruthy(input$org) || shiny::isTruthy(input$project)
+          || shiny::isTruthy(input$countryocean) || shiny::isTruthy(input$tribe_layer)
+          || shiny::isTruthy(input$tribe_name))) {
         # display a modal and return because these are not compatible
         # browser()
         shiny::showModal(shiny::modalDialog(title = "Input warning",
-          paste0("The USGS (Samples Data API) data source does not recognize the Organization(s) argument.",
-                 " Use the Organization(s) option only with the EPA (WQX) data source."), easyClose = TRUE))
+          paste0("The Data Source USGS (Samples Data API) does not recognize the Country/Ocean(s), Organization(s), Project(s), ",
+          "or Tribal Data arguments.",
+         " Use those 5 filters only with the EPA (WQX) data source."), easyClose = TRUE))
         return(NULL)
       }
       
@@ -1413,7 +1444,7 @@ mod_query_data_server <- function(id, tadat) {
             shiny::modalDialog(
               title = "Empty Query",
               "Your query returned zero results. Please adjust your search inputs and try again.
-              Remember to update the start and end dates."
+              Remember to update the Start Date and End Date."
             )
           )
           return()

--- a/tests/testthat/test-mod_load.R
+++ b/tests/testthat/test-mod_load.R
@@ -36,3 +36,246 @@ testthat::test_that("module ui works", {
     expect_true(i %in% names(fmls))
   }
 })
+
+# tests/testthat/test-example-data-map.R
+test_that("example data map returns data for each entry", {
+  testthat::skip_if_not_installed("EPATADA")
+  
+  m <- get_example_data_map()
+  
+  expect_type(m, "list")
+  expect_true(length(m) > 0L)
+  
+  for (nm in names(m)) {
+    f <- m[[nm]]
+    expect_type(f, "closure")
+    
+    obj <- f()
+    expect_false(is.null(obj), paste0(nm, " returned NULL"))
+    expect_true(is.data.frame(obj), paste0(nm, " did not return a data.frame/tibble"))
+    expect_true(NROW(obj) > 0L, paste0(nm, " has zero rows"))
+    expect_true(NCOL(obj) > 0L, paste0(nm, " has zero columns"))
+  }
+})
+
+testthat::test_that(".tadas_offline honors TADAS_OFFLINE env var", {
+  withr::local_envvar(TADAS_OFFLINE = "true")
+  expect_true(.tadas_offline())
+  
+  withr::local_envvar(TADAS_OFFLINE = "")
+  expect_false(.tadas_offline())
+})
+
+testthat::test_that(".safe_req_string returns NULL when offline", {
+  withr::local_envvar(TADAS_OFFLINE = "true")
+  expect_null(.safe_req_string("https://example.com"))
+})
+
+testthat::test_that(".safe_fetch_csv_column returns default when offline", {
+  testthat::skip_if_not_installed("data.table")
+  withr::local_envvar(TADAS_OFFLINE = "true")
+  out <- .safe_fetch_csv_column("http://does-not-matter", "Name", default = c("X"))
+  expect_identical(out, c("X"))
+})
+
+testthat::test_that(".safe_fetch_csv_column returns unique values when column present", {
+  testthat::skip_if_not_installed("data.table")
+  # Mock the internal string fetcher to avoid network
+  testthat::local_mocked_bindings(
+    .safe_req_string = function(u, ...) {
+      # headered CSV; fread can read from a single string containing data
+      "Name,Other\nA,1\nB,2\nA,3\n"
+    },
+    .env = environment(.safe_fetch_csv_column)
+  )
+  out <- .safe_fetch_csv_column("http://dummy", "Name", default = character())
+  expect_identical(sort(out), c("A", "B"))
+})
+
+testthat::test_that(".safe_fetch_csv_column returns default if column missing", {
+  testthat::skip_if_not_installed("data.table")
+  testthat::local_mocked_bindings(
+    .safe_req_string = function(u, ...) {
+      "ID,Other\n1,2\n3,4\n"
+    },
+    .env = environment(.safe_fetch_csv_column)
+  )
+  out <- .safe_fetch_csv_column("http://dummy", "Name", default = "fallback")
+  expect_identical(out, "fallback")
+})
+
+testthat::test_that(".safe_fetch_projects returns unique ProjectIdentifier list or empty on offline", {
+  testthat::skip_if_not_installed("data.table")
+  
+  # Offline path -> empty character()
+  withr::local_envvar(TADAS_OFFLINE = "true")
+  expect_identical(.safe_fetch_projects("http://dummy"), character())
+  
+  # Happy path with mock
+  withr::local_envvar(TADAS_OFFLINE = "")
+  testthat::local_mocked_bindings(
+    .safe_req_string = function(u, ...) {
+      "ProjectIdentifier,Other\nP1,x\nP2,x\nP1,y\n"
+    },
+    .env = environment(.safe_fetch_projects)
+  )
+  out <- .safe_fetch_projects("http://dummy")
+  expect_identical(sort(out), c("P1", "P2"))
+})
+
+testthat::test_that(".safe_fetch_county returns empty df with expected cols when offline", {
+  withr::local_envvar(TADAS_OFFLINE = "true")
+  df <- .safe_fetch_county("http://dummy")
+  expected_cols <- c("STATE_CD", "STATE_FIPS", "COUNTY_FIPS", "COUNTY_NAME", "COUNTY_FOOBAR")
+  expect_true(is.data.frame(df))
+  expect_identical(names(df), expected_cols)
+  expect_identical(nrow(df), 0L)
+})
+
+testthat::test_that(".safe_fetch_county parses headerless census rows", {
+  testthat::skip_if_not_installed("data.table")
+  withr::local_envvar(TADAS_OFFLINE = "")
+  
+  # Provide two rows; fread(header = FALSE, col.names = cols) is used inside
+  text_rows <- paste(
+    "AL,01,001,Autauga,foo",
+    "AL,01,003,Baldwin,bar",
+    sep = "\n"
+  )
+  testthat::local_mocked_bindings(
+    .safe_req_string = function(u, ...) text_rows,
+    .env = environment(.safe_fetch_county)
+  )
+  df <- .safe_fetch_county("http://dummy")
+  expect_true(is.data.frame(df))
+  expect_identical(nrow(df), 2L)
+  expect_identical(
+    names(df),
+    c("STATE_CD", "STATE_FIPS", "COUNTY_FIPS", "COUNTY_NAME", "COUNTY_FOOBAR")
+  )
+  expect_identical(df$STATE_CD, c("AL", "AL"))
+  expect_identical(df$COUNTY_NAME, c("Autauga", "Baldwin"))
+})
+
+testthat::test_that("restrict_to_keep_cols preserves order, drops extras, and reports messages", {
+  # Create a df with a mix of keep and extra columns
+  keep_cols <- c("A", "B", "C", "D")
+  df <- data.frame(
+    C = 3:4,
+    X = 1:2,  # extra
+    A = 5:6,
+    Y = 7:8,  # extra
+    B = 9:10,
+    stringsAsFactors = FALSE
+  )
+  
+  expect_message(
+    out <- restrict_to_keep_cols(df, keep_cols = keep_cols, verbose = TRUE),
+    regexp = "Removing 2 column\\(s\\): X, Y"
+  )
+  expect_message(
+    out <- restrict_to_keep_cols(df, keep_cols = keep_cols, verbose = TRUE),
+    regexp = "Requested but not present in input \\(not added\\): D"
+  )
+  
+  expect_identical(names(out), c("A", "B", "C"))
+  expect_identical(ncol(out), 3L)
+})
+
+testthat::test_that("restrict_to_keep_cols emits no messages when verbose = FALSE", {
+  keep_cols <- c("A", "B")
+  df <- data.frame(A = 1, C = 2, B = 3)
+  expect_silent(out <- restrict_to_keep_cols(df, keep_cols = keep_cols, verbose = FALSE))
+  expect_identical(names(out), c("A", "B"))
+})
+
+testthat::test_that("return_tribal_sf returns an sf subset for chosen layer/name", {
+  testthat::skip_if_not_installed("sf")
+  
+  # Ensure tribal_list is available (loaded from extdata at package load)
+  testthat::skip_if_not(is.list(tribal_list), "tribal_list is not available")
+  
+  layers <- names(tribal_list)
+  testthat::skip_if(length(layers) == 0, "tribal_list has no layers")
+  
+  layer <- layers[[1]]
+  df_layer <- tribal_list[[layer]]
+  
+  testthat::skip_if_not(is.data.frame(df_layer))
+  testthat::skip_if_not("TRIBE_NAME" %in% names(df_layer))
+  
+  # Take one or two names present in the layer
+  take <- unique(df_layer$TRIBE_NAME)[1]
+  testthat::skip_if(is.na(take) || length(take) == 0)
+  
+  sub <- return_tribal_sf(tribal_layer = layer, tribal_name = take, tribal_list = tribal_list)
+  expect_true(inherits(sub, "sf") || "sf_column" %in% names(attributes(sub)))
+  expect_true(all(sub$TRIBE_NAME %in% take))
+})
+
+testthat::test_that("mod_query_data_ui builds a namespaced UI with expected controls", {
+  ui <- mod_query_data_ui("query_data_1")
+  rendered <- htmltools::renderTags(ui)$html
+  
+  # Spot-check a few important inputs are properly namespaced
+  expect_match(rendered, 'id="query_data_1-example_data"', perl = TRUE)
+  expect_match(rendered, 'id="query_data_1-example_data_go"', perl = TRUE)
+  expect_match(rendered, 'id="query_data_1-state"', perl = TRUE)
+  expect_match(rendered, 'id="query_data_1-county"', perl = TRUE)
+  expect_match(rendered, 'id="query_data_1-querynow"', perl = TRUE)
+  expect_match(rendered, 'id="query_data_1-providers"', perl = TRUE)
+})
+
+# tests/testthat/test-mod-query-data-server-example.R
+testthat::test_that("mod_query_data_server loads example data and initializes tadat", {
+  testthat::skip_if_not_installed("shinyjs")
+  testthat::skip_if_not_installed("shinybusy")
+  testthat::skip_if_not_installed("EPATADA")
+  
+  # Ensure the example map exists and has entries
+  testthat::skip_if(!exists("example_data_map"), "example_data_map not found")
+  testthat::skip_if(length(names(example_data_map)) == 0, "No example datasets available")
+  
+  # Mock the bbox submodule so it doesn't need a real UI
+  testthat::local_mocked_bindings(
+    mod_map_bboxServer = function(id) {
+      # match the shape your server expects
+      list(bBox = NULL)
+    },
+    .env = environment(mod_query_data_server)
+  )
+  
+  # A fresh reactiveValues store for the module to populate
+  tadat <- shiny::reactiveValues()
+  
+  shiny::testServer(mod_query_data_server, args = list(tadat = tadat), {
+    # Seed inputs that the server uses in if(...) checks to avoid NULL -> length-0 logical errors
+    session$setInputs(
+      match_type_selector = "contains",
+      text_string = "",
+      # These aren’t required for the example path, but make other observers safe
+      media = NULL,
+      org = NULL,
+      project = NULL,
+      state = "",
+      county = "",
+      providers = "all",
+      tribe_layer = "",
+      tribe_name = ""
+    )
+    session$flushReact()
+    
+    # Trigger the example-data flow
+    session$setInputs(example_data = names(example_data_map)[1])
+    session$flushReact()
+    session$setInputs(example_data_go = 1)
+    session$flushReact()
+    
+    # Validate side effects
+    testthat::expect_true(isTRUE(tadat$ready_for_download))
+    testthat::expect_true(is.data.frame(tadat$raw))
+    testthat::expect_gt(nrow(tadat$raw), 0L)
+    testthat::expect_identical(tadat$original_source, "Example")
+    testthat::expect_true(all(names(tadat$raw) %in% all.cols))
+  })
+})


### PR DESCRIPTION
### Pull Request Checklist (convert PR to draft if in progress)

-   [y ] Update your branch from the latest `develop` and resolve any merge conflicts

-   [y ] Run devtools::test(), devtools::check(), and devtools::document() locally; ensure tests pass and fix any errors, warnings, or notes. Add new dependencies to `DESCRIPTION` and document appropriately

-   [ y] Request review from at least one developer team member (convert PR to ready for review if it was designated as in progress) - Cristina

-   [ ] Include a summary of the changes made and relevant context/motivation
This addresses 2 issues
1) The example data on the load page got out of sync with original options.  Updated logic to load a map of options.
2) Reorganized Load tab to group 'WQX' only filter options.  Also to alert users if they use a WQX only filter while trying to query USGS data.

-   [ y] Link issues to auto-close on merge (use Development sidebar or include "Closes #<issue-number>" in the PR)
I think I got that right.

-   [ ] Refresh inline/block comments for clarity

-   [ ] Review the bot's coverage report and add/update tests in `tests/testthat`

-   [ ] If there is a bot spelling comment, run spelling::spell_check_package() locally and fix any misspellings; add approved project terms to WORDLIST with spelling::update_wordlist()
