### PR TITLE
Handle large-bbox WQP timeouts with clearer guidance

### DIFF
--- a/R/mod_load.R
+++ b/R/mod_load.R
@@ -114,6 +114,34 @@ example_data_map <- get_example_data_map()
   as.data.frame(dt)
 }
 
+.format_wqp_query_error_message <- function(error_message) {
+  if (is.null(error_message)) {
+    return("An error occurred while querying WQX (EPA). Please try again.")
+  }
+
+  message_text <- as.character(error_message)
+  normalized_message <- tolower(message_text)
+
+  timeout_detected <- grepl(
+    "timeout|timed out|gateway timeout|\\b504\\b",
+    normalized_message,
+    perl = TRUE
+  )
+
+  if (timeout_detected) {
+    return(paste(
+      "The query timed out before the Water Quality Portal could return data.",
+      "Try reducing the bounding box size or adding more filters, then run the query again."
+    ))
+  }
+
+  if (!nzchar(message_text)) {
+    return("An error occurred while querying WQX (EPA). Please try again.")
+  }
+
+  paste("An error occurred while querying WQX (EPA):", message_text)
+}
+
 TADA_download_temp <- readRDS(system.file(
   "extdata",
   "TADA_download_temp.rds",
@@ -1890,7 +1918,26 @@ mod_query_data_server <- function(id, tadat) {
 
         # Get the data summary
         # does this have recent USGS data????
-        result_summary <- dataRetrieval::whatWQPdata(args_temp)
+        result_summary <- tryCatch(
+          {
+            dataRetrieval::whatWQPdata(args_temp)
+          },
+          error = function(e) {
+            shinybusy::remove_modal_spinner(
+              session = shiny::getDefaultReactiveDomain()
+            )
+            shiny::showModal(shiny::modalDialog(
+              title = "WQP Error",
+              .format_wqp_query_error_message(conditionMessage(e)),
+              easyClose = TRUE
+            ))
+            NULL
+          }
+        )
+
+        if (is.null(result_summary)) {
+          return()
+        }
 
         # Check if anything is outside the tribal's shapefile boundary
         if (inherits(tadat$tribal_boundary, "sf")) {

--- a/R/mod_load.R
+++ b/R/mod_load.R
@@ -135,6 +135,20 @@ example_data_map <- get_example_data_map()
     ))
   }
 
+  too_large_detected <- grepl(
+    "uri too long|url too long|request-uri too large|\\b414\\b",
+    normalized_message,
+    perl = TRUE
+  )
+
+  if (too_large_detected) {
+    return(paste(
+      "The query returned too many sites for the Water Quality Portal to fetch in one request",
+      "(the request URL exceeded the server length limit).",
+      "Try reducing the bounding box size or adding more filters, then run the query again."
+    ))
+  }
+
   if (!nzchar(message_text)) {
     return("An error occurred while querying WQX (EPA). Please try again.")
   }
@@ -2060,11 +2074,8 @@ mod_query_data_server <- function(id, tadat) {
                     session = shiny::getDefaultReactiveDomain()
                   )
                   shiny::showModal(shiny::modalDialog(
-                    title = "Error",
-                    paste(
-                      "An error occurred while querying WQX (EPA):",
-                      e$message
-                    ),
+                    title = "WQP Error",
+                    .format_wqp_query_error_message(conditionMessage(e)),
                     easyClose = TRUE
                   ))
                 }

--- a/tests/testthat/test-mod_load.R
+++ b/tests/testthat/test-mod_load.R
@@ -154,6 +154,31 @@ testthat::test_that(".safe_fetch_county parses headerless census rows", {
   expect_identical(df$COUNTY_NAME, c("Autauga", "Baldwin"))
 })
 
+testthat::test_that(".format_wqp_query_error_message gives bbox guidance for timeout errors", {
+  msg <- .format_wqp_query_error_message("504 Gateway Timeout")
+
+  expect_match(msg, "timed out", ignore.case = TRUE)
+  expect_match(msg, "bounding box", ignore.case = TRUE)
+})
+
+testthat::test_that(".format_wqp_query_error_message preserves non-timeout details", {
+  msg <- .format_wqp_query_error_message("certificate verification failed")
+
+  expect_match(msg, "An error occurred while querying WQX \\(EPA\\):")
+  expect_match(msg, "certificate verification failed")
+})
+
+testthat::test_that(".format_wqp_query_error_message handles empty message safely", {
+  expect_identical(
+    .format_wqp_query_error_message(""),
+    "An error occurred while querying WQX (EPA). Please try again."
+  )
+  expect_identical(
+    .format_wqp_query_error_message(NULL),
+    "An error occurred while querying WQX (EPA). Please try again."
+  )
+})
+
 testthat::test_that("restrict_to_keep_cols preserves order, drops extras, and reports messages", {
   # Create a df with a mix of keep and extra columns
   keep_cols <- c("A", "B", "C", "D")

--- a/tests/testthat/test-mod_load.R
+++ b/tests/testthat/test-mod_load.R
@@ -161,6 +161,13 @@ testthat::test_that(".format_wqp_query_error_message gives bbox guidance for tim
   expect_match(msg, "bounding box", ignore.case = TRUE)
 })
 
+testthat::test_that(".format_wqp_query_error_message gives bbox guidance for URL-too-long errors", {
+  msg <- .format_wqp_query_error_message("HTTP 414 URI Too Long")
+
+  expect_match(msg, "too many sites", ignore.case = TRUE)
+  expect_match(msg, "bounding box", ignore.case = TRUE)
+})
+
 testthat::test_that(".format_wqp_query_error_message preserves non-timeout details", {
   msg <- .format_wqp_query_error_message("certificate verification failed")
 


### PR DESCRIPTION
Fixes #318

Large bounding-box queries can time out during whatWQPdata(), which currently bubbles up as an unhandled error. This catches that error path, closes the loading spinner, and shows a clearer modal that suggests reducing bounding box size or adding filters when timeout or gateway errors occur.

I also added focused unit tests for the new error-message formatter, including timeout and non-timeout cases.